### PR TITLE
Use stamped Docker image by default

### DIFF
--- a/charts/timescaledb-single/README.md
+++ b/charts/timescaledb-single/README.md
@@ -149,7 +149,7 @@ backup:
   secretAccessKey: 5CrhvJD08bp9emxI+D48GXfDdtl823nlSRRv7dmB
 ```
 ```
-helm upgrade --install example -f myvalues.yaml
+helm upgrade --install example -f myvalues.yaml .
 ```
 
 ### Control the backup schedule

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -8,7 +8,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescaledev/timescaledb-ha
-  tag: 78603166-pg11-custom
+  tag: v0.2.0-pg11
   pullPolicy: IfNotPresent
 
 # Credentials used by PostgreSQL and Patroni


### PR DESCRIPTION
The upstream Docker image is now released in a controlled fashion. We
should use a released version as much as possible.

In passing, fix a missing argument in the README.