### PR TITLE
Pass on metadata labels to Jobs and Pods

### DIFF
--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -34,8 +34,22 @@ spec:
   concurrencyPolicy: Forbid
   ttlSecondsAfterFinished: 3600
   jobTemplate:
+    metadata:
+      labels:
+        app: {{ template "timescaledb.fullname" $ }}
+        chart: {{ template "timescaledb.chart" $ }}
+        release: {{ $.Release.Name }}
+        heritage: {{ $.Release.Service }}
+        backup-type: {{ .type }}
     spec:
       template:
+        metadata:
+          labels:
+            app: {{ template "timescaledb.fullname" $ }}
+            chart: {{ template "timescaledb.chart" $ }}
+            release: {{ $.Release.Name }}
+            heritage: {{ $.Release.Service }}
+            backup-type: {{ .type }}
         spec:
           containers:
           - name: {{ template "timescaledb.fullname" $ }}-{{ .type }}


### PR DESCRIPTION
Adding the metadata labels to not just the CronJobs, but also the Jobs
it creates and subsequently the Pods that are created to fullfil the job
allows us to easily identify all the objects belonging to a release.

As an example, to list all the jobs that are part of a release, after
this commit we can do the following:

    kubectl get job -l release=my-release

whereas previously we were condemned to using grep or other filtering to
find the jobs we're interested in.