### PR TITLE
Add CHANGELOG to prepare regular releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v0.1.0] - 2019-09-04
+
+### Added
+ *  Helm chart for `timescaledb-single`
+ *  Documentation for the `timescaledb-single` Helm chart


### PR DESCRIPTION
As our delivery model for the Helm charts will also include sending out
tar archives of releases, we need to keep up a good release process.

Adding the file starts this process, if merged, we can stamp v0.1.0