### PR TITLE
Set the apiVersion to v1 where possible

### DIFF
--- a/charts/timescaledb-single/templates/role-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/role-timescaledb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "timescaledb.fullname" . }}

--- a/charts/timescaledb-single/templates/rolebinding-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/rolebinding-timescaledb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "timescaledb.fullname" . }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "timescaledb.fullname" . }}


### PR DESCRIPTION
Apart from the batch/v1beta1, all other kinds are stable in Kubernetes
1.12