### PR TITLE
Add instructions for locally-built images

### DIFF
--- a/charts/timescaledb-multinode/README.md
+++ b/charts/timescaledb-multinode/README.md
@@ -12,7 +12,7 @@ When deploying on AWS EKS:
 
 ## Installing
 
-To install the chart with the release name `my-release`:
+To install the chart as a release and name it `my-release`:
 
 ```console
 helm install --name my-release .
@@ -34,9 +34,36 @@ helm install --name my-release -f myvalues.yaml .
 
 For details about what parameters you can set, have a look at the [Administrator Guide](admin-guide.md#configure)
 
+## Using a local image
+
+During development, it is practical to be able to use a locally built image of TimescaleDB multinode without having to push it to a registry. This can be done as follows:
+
+```console
+# Setup the environment to use Minikube's Docker daemon
+eval $(minikube docker-env)
+
+# Build a new image (this requires being in the TimescaleDB source directory):
+IMAGE_NAME=mytsdb TAG_NAME=build-1 ../scripts/docker-build.sh
+```
+If you don't specify an image name and tag name, like above, make note of the name and the tag of the new image that gets built. Then launch multinode TimescaleDB using the new image:
+
+```console
+helm install --name my-release --set image.repository=mytsdb --set image.tag=build-1 .
+```
+
 ## Connecting to TimescaleDBs
 
-To connect to the TimescaleDB instance, we first need to know to which host we need to connect. Use `kubectl` to get that information:
+Once the multinode deployment of TimescaleDB is running, you can connect to the access node:
+
+```console
+kubectl exec -it my-release-timescaledb-access-0 -- psql -U postgres
+```
+
+### Connecting from outside Kubernetes
+If you want to connect directly to the access node, without going
+through Kubernetes, you need to know the host (and port) to connect
+to. Use `kubectl` to get that information:
+
 ```console
 kubectl get service/my-release-timescaledb
 ```
@@ -45,8 +72,9 @@ NAME                             TYPE           CLUSTER-IP      EXTERNAL-IP     
 service/my-release-timescaledb   LoadBalancer   10.100.157.80   verylongname.example.com   5432:32641/TCP   79s
 ```
 
-Using the External IP for the service (which will route through the LoadBalancer to the Access Node), you
-can connect via `psql` using the following (default example superuser password is `tea`)
+Using the External IP for the service (which will route through the
+LoadBalancer to the Access Node), you can connect via `psql` using the
+following (default example superuser password is `tea`)
 
 ```console
 psql -h verylongname.example.com -U postgres
@@ -72,14 +100,24 @@ This should get you into the example database, from here on you can follow
 our [TimescaleDB > Tutorial: Scaling out TimescaleDB](https://docs.timescale.com/clustering/tutorials/clustering)
 to create distributed hypertables and start using multinode TimescaleDB.
 
-### Connecting from inside the Cluster
+### Connecting from another pod
 
-To access the database from inside the cluster, spin up another Pod to run `psql`:
+From inside a pod in the Kubernetes cluster, you need to use the
+internal DNS address, e.g.,
+`my-release-timescaledb.default.svc.cluster.local`. For instance,
+let's run a new pod where we can run the PostgreSQL client:
 
+```console
+kubectl run -i --tty --rm psql --image=postgres --restart=Never -- bash -il
 ```
-kubectl run -i --tty --rm psql --image=postgres --restart=Never -- psql -U postgres -h my-release-timescaledb.default.svc.cluster.local  postgres
+
+Then from within the Pod, connect to the access node:
+
+```console
+$ psql -U postgres -h my-release-timescaledb.default.svc.cluster.local postgres
 ```
-provide the password `tea` followed by "Enter" when you see the message `If you don't see a command prompt, try pressing enter.` (Yes, this is a bit quirky. To avoid it, first launch a shell and then run the `psql` client.)
+
+provide the password `tea` followed by "Enter".
 
 ## Cleanup
 


### PR DESCRIPTION
This change adds a section on how to build and launch images that are built locally. This is useful in development environments where you'd like to do frequent changes to the code.