### PR TITLE
Use emptyDir for PostgreSQL Sockets

### DIFF
--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Create the name of the service account to use.
 {{- end -}}
 
 {{- define "socket_directory" -}}
-{{ .Values.persistentVolume.mountPath }}
+/var/run/postgresql/
 {{- end -}}
 
 {{- define "data_directory" -}}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -111,6 +111,8 @@ spec:
         - mountPath: /etc/certificate
           name: certificate
           readOnly: true
+        - name: socket-directory
+          mountPath: /var/run/postgresql
 {{- if .Values.backup.enable }}
         - mountPath: /etc/pgbackrest
           name: pgbackrest
@@ -128,6 +130,9 @@ spec:
         ports:
         - containerPort: 8081
         volumeMounts:
+        - name: socket-directory
+          mountPath: /var/run/postgresql
+          readOnly: true
         - name: storage-volume
           mountPath: {{ .Values.persistentVolume.mountPath | quote }}
           subPath: {{ .Values.persistentVolume.subPath | quote }}
@@ -165,6 +170,9 @@ spec:
 {{ tpl .Values.affinityTemplate . | indent 8 }}
     {{- end }}
       volumes:
+      - name: socket-directory
+        emptyDir:
+          defaultMode: 488 # 0750 permissions
       - name: patroni-config
         configMap:
           name: {{ template "timescaledb.fullname" . }}-patroni

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -118,10 +118,7 @@ patroni:
           tcp_keepalives_interval: 100
           temp_file_limit: 1GB
           timescaledb.passfile: '../.pgpass'
-          # Adding the directory where the pgdata is volume is mounted to the socket dirs
-          # allows other pods in the container to connect using the socket. The pgBackRest sidecar
-          # for example needs this
-          unix_socket_directories: "/var/run/postgresql,/home/postgres/pgdata"
+          unix_socket_directories: "/var/run/postgresql"
           wal_level: hot_standby
           wal_log_hints: 'on'
           work_mem: 16MB


### PR DESCRIPTION
The previous solution required the data volume to be shared as the
sockets were put on the data volume.
By having an emptyDir we can expose the socket to a sidecar container,
without exposing the data directory.