### PR TITLE
Express that pods should run in different zones

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -199,6 +199,15 @@ affinityTemplate: |
           matchLabels:
             app:  {{ template "timescaledb.name" . }}
             release: {{ .Release.Name | quote }}
+            cluster-name: {{ template "clusterName" . }}
+    - weight: 50
+      podAffinityTerm:
+        topologyKey: failure-domain.beta.kubernetes.io/zone
+        labelSelector:
+          matchLabels:
+            app:  {{ template "timescaledb.name" . }}
+            release: {{ .Release.Name | quote }}
+            cluster-name: {{ template "clusterName" . }}
 affinity: {}
 
 ## Use an alternate scheduler, e.g. "stork".


### PR DESCRIPTION
The default antiAffinity only took the hostname into account. As we
expect many deployments to have availability zones, we include that in
the antiAffinity so that pods will be spread across availability zones
by default.

For example, this should ensure that when running in us-east-2 and
deploying 3 pods, they should end up in the following availability zones
(given that Kubernetes Nodes are deployed):

us-east-2a
us-east-2b
us-east-2c