### PR TITLE
Bugfix: Tell the LoadBalancer which port to follow

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -133,6 +133,10 @@ patroni:
     role_label: role
     scope_label: cluster-name
     use_endpoints: true
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
   postgresql:
     callbacks: {}
     authentication:


### PR DESCRIPTION
The Service and Endpoint port names need to match, see:
https://patroni.readthedocs.io/en/latest/SETTINGS.html#kubernetes