### PR TITLE
Bugfix: Tell the LoadBalancer which port to follow

### DIFF
--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -11,7 +11,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{- define "clusterName" -}}
-{{- default (printf "%s-%s" .Release.Namespace .Release.Name) .Values.clusterName | trunc 63 -}}
+{{- default .Release.Name .Values.clusterName | trunc 63 -}}
 {{- end -}}
 
 {{/*

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "timescaledb.fullname" . }}
+  name: {{ template "clusterName" . }}
   labels:
     app: {{ template "timescaledb.fullname" . }}
     chart: {{ template "timescaledb.chart" . }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 3
 # timescaledb-single (the name of the chart)
 nameOverride: timescaledb
 
-# The default Patroni name of the cluster ("scope") is derived from the namespace and the name of the release,
+# The default Patroni name of the cluster ("scope") is derived from the name of the release,
 # but you can override this behaviour here
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#global-universal
 clusterName:
@@ -133,6 +133,10 @@ patroni:
     role_label: role
     scope_label: cluster-name
     use_endpoints: true
+    ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
   postgresql:
     callbacks: {}
     authentication:


### PR DESCRIPTION
The Service and Endpoint port names need to match, see:
https://patroni.readthedocs.io/en/latest/SETTINGS.html#kubernetes

Part of this is the renaming of clusterName; the name does not need to
be globally unique and therefore adding the namespace to the name is not
needed.

In this way we get some shorter, cleaner names for the objects
generated.