### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+These are changes that will probably be included in the next release.
+
+### Added
+### Changed
+### Removed
+### Fixed
+
+## [v0.2.0] - 2019-10-16
+### Added
+ * A preliminary multinode Helm chart
+ * Architecture diagrams
+ * Allow multiple volumes for the data directory and the WAL directory
+ * Documentation pgBackRest restore outside of Kubernetes environment
+
+### Changed
+ * The defined Patroni configuration is passed on (using a ConfigMap) to Patroni
+ * Secrets required by Patroni are injected using environment variables
+ * The defined pgBackRest configuration is passed on to pgBackRest (using a Secret as it holds credentials)
+ * The entrypoint no longer points to scripts in the Docker image, this pretty much allows any Docker image
+     to be used, as long as it contains PostgreSQL, TimescaleDB, and pgBackRest
+ * Best practice PostgreSQL parameters, e.g. enable logging of connections by default
+ * Open Sourced this repository as Apache License 2.0
+
 ## [v0.1.0] - 2019-09-04
 
 ### Added

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-multinode
 description: 'TimescaleDB Multinode Deployment.'
-version: 0.1.0
+version: 0.2.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.1.0
+version: 0.2.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field


### PR DESCRIPTION
## [v0.2.0] - 2019-10-16
### Added
 * A preliminary multinode Helm chart
 * Architecture diagrams
 * Allow multiple volumes for the data directory and the WAL directory
 * Documentation pgBackRest restore outside of Kubernetes environment

### Changed
 * The defined Patroni configuration is passed on (using a ConfigMap) to Patroni
 * Secrets required by Patroni are injected using environment variables
 * The defined pgBackRest configuration is passed on to pgBackRest (using a Secret as it holds credentials)
 * The entrypoint no longer points to scripts in the Docker image, this pretty much allows any Docker image
     to be used, as long as it contains PostgreSQL, TimescaleDB, and pgBackRest
 * Best practice PostgreSQL parameters, e.g. enable logging of connections by default
 * Open Sourced this repository as Apache License 2.0