### PR TITLE
Document that WAL Volume is enabled by default

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -39,7 +39,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `persistentVolumes.data.enabled`  | If enabled, use a Persistent Data Volume    | `true`                                              |
 | `persistentVolumes.data.mountPath`| Persistent Data Volume mount root path      | `/var/lib/postgresql/`                              |
-| `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume     | `false` (WAL will be stored inside the Data Volume) |
+| `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume. If disabled, WAL will be on the Data Volume | `true`     |
 | `persistentVolumes.wal.mountPath` | Persistent Wal Volume mount root path       | `/var/lib/postgresql/wal/`                          |
 | `persistentVolumes.<name>.accessModes` | Persistent Volume access modes         | `[ReadWriteOnce]`                                   |
 | `persistentVolumes.<name>.annotations` | Annotations for Persistent Volume Claim| `{}`                                                |


### PR DESCRIPTION
The WAL Volume was enabled by default in
188848d4111b77f98c7b3fa3878191d634981d06, however the documentation did
not reflect this change.

I was wondering whether to revert the WAL Volume being enabled by
default or by patching the documentation, I think having separate
volumes should be the default, so I decided to change the documentation.

Backpatch to 0.2