### PR TITLE
Bugfix: Always set wal directory, regardles of Volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 ### Fixed
+ * Always explicitly set wal directory
 
 ## [v0.2.0] - 2019-10-16
 ### Added

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -59,9 +59,5 @@ Create the name of the service account to use.
 {{- end -}}
 
 {{- define "wal_directory" -}}
-{{- if .Values.persistentVolumes.wal.enabled -}}
 {{ printf "%s/pg_wal" .Values.persistentVolumes.wal.mountPath }}
-{{- else -}}
-
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Commit 188848d4111b77f98c7b3fa3878191d634981d06 introduced the
possibility to create separate WAL Volumes. With that change, the WAL
directory will now always be outside the PGDATA directory, even if the
Volume is the same.

We should therefore always set the wal_directory.

This came to light with error messages when running
`install [...] ""` where the wal_directory should have been inserted.

Backpatch to 0.2