### PR TITLE
Allow configuration of the Load Balancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+ * Allow annotations to be specified for the Load Balancer in the values.yaml file
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -37,6 +37,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname and (availability) zone |
 | `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
+| `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
 | `persistentVolumes.data.enabled`  | If enabled, use a Persistent Data Volume    | `true`                                              |
 | `persistentVolumes.data.mountPath`| Persistent Data Volume mount root path      | `/var/lib/postgresql/`                              |
 | `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume. If disabled, WAL will be on the Data Volume | `true`     |

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
     cluster-name: {{ template "clusterName" . }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
+{{ .Values.loadBalancer.annotations | toYaml | indent 4 }}
 spec:
   type: LoadBalancer
 

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -159,6 +159,18 @@ patroni:
   restapi:
     listen: 0.0.0.0:8008
 
+loadBalancer:
+  # Read more about the AWS annotations here:
+  # https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws
+  # https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html
+  annotations:
+    # Setting idle-timeout to the maximum allowed value, as in general
+    # database connections are long lived
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
+
+    # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
+    # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
+
 persistentVolumes:
   # For sanity reasons, the actual PGDATA and wal directory will be subdirectories of the Volume mounts,
   # this allows Patroni/a human/an automated operator to move directories during bootstrap, which cannot


### PR DESCRIPTION
This feature allows you to annotate your load balancer with custom
annotations, which allows different kinds of load balancers as well as
load balancers that are internal instead of external.

The annotations that can be used are documented here:

https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html