### PR TITLE
Associate IAM role with a Service Account (AWS)

### DIFF
--- a/charts/timescaledb-single/templates/serviceaccount-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/serviceaccount-timescaledb.yaml
@@ -11,4 +11,6 @@ metadata:
     chart: {{ template "timescaledb.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
 {{- end }}


### PR DESCRIPTION
Currently, the pgBackRest backup requires secrets to do its backups to
S3. These secrets are stored as k8s secrets, however they are specified
as plain text in the values.yaml file.
By associating an IAM role with a Service Account we remove the need for
specifying these secrets in the values altogether.

https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html