### PR TITLE
Feike/private multinode beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 ### Fixed
+
+## [v0.2.1] - 2019-10-22
+
+### Changed
+ * Point to the -latest Docker image tag for multinode by default
+### Fixed
  * Always explicitly set wal directory
+ * (multinode) Drop the TimescaleDB extension from the Data Nodes to allow a clean bootstrap to be done
 
 ## [v0.2.0] - 2019-10-16
 ### Added

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-multinode
 description: 'TimescaleDB Multinode Deployment.'
-version: 0.2.0
+version: 0.2.1
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
+++ b/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
@@ -68,6 +68,9 @@ spec:
             echo "Writing custom PostgreSQL Parameters to ${PGDATA}/postgresql_helm_customizations.conf"
             echo "cluster_name = '$(hostname)'" > "${PGDATA}/postgresql_helm_customizations.conf"
             echo "${POSTGRESQL_CUSTOM_PARAMETERS}" | sort >> "${PGDATA}/postgresql_helm_customizations.conf"
+            # The TimescaleDB extension should not be available by default, as this interferes with the bootstrapping
+            # done by the access nodes. Therefore we drop the extensions from template1
+            echo "DROP EXTENSION timescaledb" | /docker-entrypoint.sh postgres --single -D "${PGDATA}" template1
         volumeMounts:
         - name: storage-volume
           mountPath: "{{ .Values.persistentVolume.mountPath }}"

--- a/charts/timescaledb-multinode/values.yaml
+++ b/charts/timescaledb-multinode/values.yaml
@@ -11,7 +11,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescaledev/timescaledb
-  tag: v0.2.2-pg11-multinode
+  tag: 2.0.0-beta2-pg11
   pullPolicy: IfNotPresent
 
 # Credentials used by PostgreSQL

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.2.0
+version: 0.2.1
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field


### PR DESCRIPTION
- [X] Point to latest Docker image to run 2.0.0-beta2 for multinode
- [X] Verify correct installation
- [X] Bump release version

    Drop Timescale extension from the Data Nodes
    
    During the process of bootstrapping Data Nodes from Access Nodes, there
    are 2 options (currently):
    
    bootstrap => false will create the database *and* install the extension
    bootstrap => true  will create neither the database nor the extension
    
    The problem with having TimescaleDB in the template1 database is that
    after  CREATE DATABASE example is executed, it already contains a
    TimescaleDB extension. This means bootstrap => true will fail, as it
    cannot install the extension.
    
    This is probably to be fixed in another way at some point, however for
    now the safe option is to drop the extension from the template1
    database.
