### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ These are changes that will probably be included in the next release.
 ### Removed
 ### Fixed
 
+## [v0.2.2] - 2019-10-31
+
+### Changed
+ * Use TimescaleDB 1.5 Docker image by default
+
 ## [v0.2.1] - 2019-10-22
 
 ### Changed

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.2.1
+version: 0.2.2
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/README.md
+++ b/charts/timescaledb-single/README.md
@@ -11,7 +11,7 @@ High Availability (HA) configuration on Kubernetes. This chart will do the follo
 
 - Creates three (by default) pods using a Kubernetes [StatefulSet](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/).
 - Each pod has a container created using the [TimescaleDB Docker image](https://github.com/timescale/timescaledb-docker-ha).
-  - TimescaleDB 1.4 and PG 11
+  - TimescaleDB 1.5 and PG 11
 - Each of the the container runs a TimescaleDB instance and [Patroni](https://patroni.readthedocs.io/en/latest/) agent.
 - Each TimescaleDB instance is configured for replication (1 Master + 2 Replicas).
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -21,7 +21,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `fullnameOverride`                | Override the fullname of the chart          | `nil`                                               |
 | `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
 | `image.repository`                | The image to pull                           | `timescaledev/timescaledb-ha`                       |
-| `image.tag`                       | The version of the image to pull            | `pg11-ts1.4`                                        |
+| `image.tag`                       | The version of the image to pull            | `pg11-ts1.5`                                        |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `credentials`                     | A mapping of usernames/passwords            | A postgres, standby and admin user                  |
 | `tls.cert`                        | The public key of the SSL certificate for PostgreSQL | empty (a self-signed certificate will be generated) |
@@ -53,13 +53,13 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 ### Examples
 - Override value using commandline parameters
     ```console
-    helm upgrade --install my-release charts/timescaledb-single --set image.tag=pg11.5-ts1.4.2 --set image.pullPolicy=Always
+    helm upgrade --install my-release charts/timescaledb-single --set image.tag=pg11.5-ts1.5.0 --set image.pullPolicy=Always
     ```
 - Override values using `myvalues.yaml`
     ```yaml
     # Filename: myvalues.yaml
     image:
-      tag: pg11.5-ts1.4.2
+      tag: pg11.5-ts1.5.0
       pullPolicy: Always
     patroni:
       postgresql:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -16,7 +16,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescaledev/timescaledb-ha
-  tag: pg11-ts1.4
+  tag: pg11-ts1.5
   pullPolicy: IfNotPresent
 
 # Credentials used by PostgreSQL and Patroni


### PR DESCRIPTION
Use TimescaleDB 1.5.0 for defaults for the timescaledb-single chart