### PR TITLE
Include a postgres-container in the Pod if enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+ * Allow [postgres-exporter](https://github.com/wrouesnel/postgres_exporter) to run as a sidecar
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -167,6 +167,25 @@ spec:
             value: /etc/pgbackrest/pgbackrest.conf
 {{ end }}
 
+{{- if .Values.postgresExporter.enable }}
+      - name: postgres-exporter
+        image: "{{ .Values.postgresExporter.image.repository }}:{{ .Values.postgresExporter.image.tag }}"
+        imagePullPolicy: {{ .Values.postgresExporter.image.pullPolicy }}
+        securityContext:
+          runAsUser: 1000
+        ports:
+        - containerPort: 9187
+        volumeMounts:
+        - name: socket-directory
+          mountPath: {{ template "socket_directory" . }}
+          readOnly: true
+        env:
+          - name: DATA_SOURCE_NAME
+            value: "host={{ template "socket_directory" . }} user=postgres application_name=postgres_exporter"
+          - name: PG_EXPORTER_CONSTANT_LABELS
+            value: release={{ .Release.Name }},namespace={{ .Release.Namespace }}
+{{ end }}
+
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -219,6 +219,15 @@ resources: {}
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+# Prometheus exporter for PostgreSQL server metrics.
+# https://github.com/wrouesnel/postgres_exporter
+postgresExporter:
+  enabled: False
+  image:
+    repository: wrouesnel/postgres_exporter
+    tag: v0.7.0
+    pullPolicy: IfNotPresent
+
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 


### PR DESCRIPTION
To allow metrics to be exported, we can run the postgres-exporter as a
sidecar to the database container.