### PR TITLE
Rename backup.enable to backup.enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ These are changes that will probably be included in the next release.
 
 ### Added
 ### Changed
+ * Rename backup.enable to backup.enabled for consistency, the old naming does still work.
 ### Removed
 ### Fixed
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -26,7 +26,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `credentials`                     | A mapping of usernames/passwords            | A postgres, standby and admin user                  |
 | `tls.cert`                        | The public key of the SSL certificate for PostgreSQL | empty (a self-signed certificate will be generated) |
 | `tls.key`                         | The private key of the SSL Certificate for PostgreSQL | empty                                     |
-| `backup.enable`                   | Schedule backups to occur                   | `false`                                             |
+| `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
 | `backup.pgBackRest`               | [pgBackRest configuration](https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml)     | Working defaults |
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
 | `env`                             | Extra custom environment variables          | `{}`                                                |
@@ -115,7 +115,7 @@ If you (re)deploy your database with this configuration snippet in the values fi
 ```yaml
 # Filename: myvalues.yaml
 backup:
-  enable: True
+  enabled: True
     pgBackRest:
       repo1-s3-bucket: this_bucket_may_not_exist
       repo1-s3-key: 9E1R2CUZBXJVYSBYRWTB

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -23,7 +23,7 @@ data:
   # Therefore, if the backup is disabled, we always return exitcode 0 when archiving
   pgbackrest_archive.sh: |
     #!/bin/bash
-    PGBACKREST_BACKUP_ENABLED={{ .Values.backup.enable | int }}
+    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
 
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 0
 
@@ -50,7 +50,7 @@ data:
     exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug
   post_init.sh: |
     #!/bin/bash
-    PGBACKREST_BACKUP_ENABLED={{ .Values.backup.enable | int }}
+    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
 
     function log {
         echo "$(date '+%Y-%m-%d %H:%M:%S') - post_init - $1"

--- a/charts/timescaledb-single/templates/sec-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/sec-pgbackrest.yaml
@@ -1,7 +1,7 @@
 # This file and its contents are licensed under the Apache License 2.0.
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 
-{{- if .Values.backup.enable }}
+{{- if or .Values.backup.enable .Values.backup.enabled }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -124,7 +124,7 @@ spec:
           readOnly: true
         - name: socket-directory
           mountPath: /var/run/postgresql
-{{- if .Values.backup.enable }}
+{{- if or .Values.backup.enabled .Values.backup.enable }}
         - mountPath: /etc/pgbackrest
           name: pgbackrest
           readOnly: true
@@ -132,7 +132,7 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 
-{{- if .Values.backup.enable }}
+{{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -215,7 +215,7 @@ spec:
         configMap:
           name: {{ template "timescaledb.fullname" . }}-scripts
           defaultMode: 488 # 0750 permissions
-{{- if .Values.backup.enable }}
+{{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         secret:
           secretName: {{ template "timescaledb.fullname" . }}-pgbackrest

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -41,7 +41,7 @@ tls:
 #    -----END PRIVATE KEY-----
 
 backup:
-  enable: false
+  enabled: false
   pgBackRest:
     # https://pgbackrest.org/configuration.html
     process-max: 4


### PR DESCRIPTION
To ensure we don't break current deployments, we do not yet deprecate
the old spelling.