### PR TITLE
Include readinessProbe for PostgreSQL by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+ * Add [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) for PostgreSQL
 ### Changed
  * Rename backup.enable to backup.enabled for consistency, the old naming does still work.
  * Rename postgresExporter to prometheus

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -14,6 +14,8 @@ metadata:
 spec:
   serviceName: {{ template "timescaledb.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       app: {{ template "timescaledb.fullname" . }}
@@ -103,6 +105,19 @@ spec:
         ports:
         - containerPort: 8008
         - containerPort: 5432
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          exec:
+            command:
+              - pg_isready
+              - -h
+              - {{ template "socket_directory" . }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: storage-volume
           mountPath: {{ .Values.persistentVolumes.data.mountPath | quote }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -171,6 +171,14 @@ loadBalancer:
     # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
     # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
 
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
 persistentVolumes:
   # For sanity reasons, the actual PGDATA and wal directory will be subdirectories of the Volume mounts,
   # this allows Patroni/a human/an automated operator to move directories during bootstrap, which cannot


### PR DESCRIPTION
According to the Kubernetes Documentation[1], this is how pods are
rescheduled currently:

    ... updating each Pod one at a time. It will wait until an updated
    Pod is Running and Ready prior to updating its predecessor...

Without the readinessProbe the container running PostgreSQL was
considered Ready very quickly after startup. However, we can express
readiness much better by saying that it needs to *at least* be able to
connect to the PostgreSQL instance in the container before the container
can be marked ready.

This fixes a problem like the following scenario:

- An update to the Pod Template, requiring a rescheduling of all the
  pods
- A somewhat large - or active - database that requires significant time
  to be restored

What would happen is that a RollingUpdate strategy (which is the default
but with this commit is also made explicit), the first pod to be
restarted would be marked Ready way before it could even accept
PostgreSQL connections, let alone be a candidate for a master failover.

This readinessProbe is not perfect, as it only verifies if connections
are allowed. Not whether the StatefulSet as a whole can currently cope
with a failover.

That is not easily solved with only ReadinessProbes, as it requires a
distributed decision on whether or not this pod is healthy enough. That
is where a Helm Chart / StatefulSet / updateStrategy start to show its
limitations and where an operator can make the correct decisions.

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#rolling-updates