### PR TITLE
Allow a (debug) command to run at container start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ These are changes that will probably be included in the next release.
 
 ### Added
  * Add [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes) for PostgreSQL
+ * Allow a (debug) command to run at container startup
 ### Changed
  * Rename backup.enable to backup.enabled for consistency, the old naming does still work.
  * Rename postgresExporter to prometheus

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -44,6 +44,7 @@ spec:
           # of the PGDATA and/or wal directory are incorrect. To guard against this, we always correctly
           # set the permissons of these directories before we hand over to Patroni
           - |
+            {{ .Values.debug.execStartPre }}
             install -o postgres -g postgres -d -m 0700 {{ include "data_directory" . | quote }} {{ include "wal_directory" . | quote }}
             exec patroni /etc/timescaledb/patroni.yaml
         env:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -276,3 +276,10 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+debug:
+  # This setting is mainly for during development, debugging or troubleshooting.
+  # This command will be executed *before* the main container starts. In the
+  # example below, we can mimick a slow restore by sleeping for 5 minutes before starting
+  execStartPre: # sleep 300
+


### PR DESCRIPTION
During development it sometimes is useful to mimick certain situations,
like a delayed startup (due to a long-running restore for example), or
to allow you to execute a command in the container before the regular
commands start.

Another scenario where this may be useful is to aid in troubleshooting a
deployment, where by adding a long running sleep an operator may be able
to investigate or even solve a troublesome restore or startup of
PostgreSQL.