### PR TITLE
Quiet down Patroni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ These are changes that will probably be included in the next release.
 
 ### Added
 ### Changed
+ * Reduce loglevel of Patroni from INFO to WARNING
 ### Removed
 ### Fixed
 

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -79,7 +79,7 @@ env: {}
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#settings
 patroni:
   log:
-    level: INFO
+    level: WARNING
   bootstrap:
     post_init: /etc/timescaledb/scripts/post_init.sh
     dcs:


### PR DESCRIPTION
Patroni is pretty chatty by default, which is not needed in most
deployments.