### PR TITLE
Add ability to set annotations on pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+
+* Add ability to [annotate](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) pods in the StatefulSet
+
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.2.4
+version: 0.2.5
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -27,6 +27,10 @@ spec:
         app: {{ template "timescaledb.fullname" . }}
         release: {{ .Release.Name }}
         cluster-name: {{ template "clusterName" . }}
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ template "timescaledb.serviceAccountName" . }}
       securityContext:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -246,6 +246,10 @@ prometheus:
     tag: v0.7.0
     pullPolicy: IfNotPresent
 
+# Annotations that are applied to each pod in the stateful set
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 
@@ -292,4 +296,3 @@ debug:
   # This command will be executed *before* the main container starts. In the
   # example below, we can mimick a slow restore by sleeping for 5 minutes before starting
   execStartPre: # sleep 300
-


### PR DESCRIPTION
Being able to annotate the pods created in the StatefulSet is
useful for being able to enable things like network policies, telling
the pod how to connect to other services, integration with things
like kiam, and more.