### PR TITLE
WIP: Bootstrap from backup if available

### DIFF
--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -28,6 +28,12 @@ data:
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 0
 
     exec pgbackrest --stanza=poddb archive-push $1
+  pgbackrest_archive_get.sh: |
+    #!/bin/bash
+    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
+    [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 1
+
+    exec pgbackrest --stanza=poddb archive-get ${1} "${2}"
   pgbackrest_bootstrap.sh: |
     #!/bin/bash
     set -e
@@ -48,6 +54,12 @@ data:
 
     log "Starting pgBackrest api to listen for backup requests"
     exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug
+  pgbackrest_restore.sh: |
+    #!/bin/bash
+    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
+    [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 1
+
+    pgbackrest --stanza=poddb --delta --log-level-console=detail restore
   post_init.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -38,7 +38,6 @@ metadata:
 spec:
   schedule: {{ quote .schedule }}
   concurrencyPolicy: Forbid
-  ttlSecondsAfterFinished: 3600
   jobTemplate:
     metadata:
       labels:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -149,8 +149,18 @@ patroni:
       port: 5432
       targetPort: 5432
   postgresql:
+    create_replica_methods:
+    - pgbackrest
+    - basebackup
+    pgbackrest:
+      command: /etc/timescaledb/scripts/pgbackrest_restore.sh
+      keep_data: True
+      no_params: True
+      no_master: 1
     basebackup:
     - waldir: "/var/lib/postgresql/wal/pg_wal"
+    recovery_conf:
+      restore_command: /etc/timescaledb/scripts/pgbackrest_archive_get.sh %f "%p"
     callbacks:
       on_role_change: /etc/timescaledb/scripts/patroni_callback.sh
       on_start: /etc/timescaledb/scripts/patroni_callback.sh


### PR DESCRIPTION
- [x] Create a wrapper script around pgBackrest to do the restore[1]
- [x] Wrapper script should `exit 1` (or similar) quickly if no backup is configured
- [x] Configure Patroni `postgresql` section in such a way that this script is called first
- [x] `no_master` should be set to allow us to suspend and resume a full cluster from the backup only

1: pgBackRest will balk on the flags `--scope` which are passed on by Patroni, so a wrapper script is required.

Inspiration:
https://github.com/zalando/patroni/blob/master/docs/replica_bootstrap.rst