### PR TITLE
Ensure Backup Jobs are defined

### DIFF
--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -1,7 +1,7 @@
 # This file and its contents are licensed under the Apache License 2.0.
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 
-{{- if .Values.backup.enable }}
+{{- if or .Values.backup.enable .Values.backup.enabled }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
In commit 44b9e1fc6541226a9af33291c614a5cd7fc9e954 we renamed
backup.enable to backup.enabled, but somehow passed over this reference.