### PR TITLE
Use Patroni Callbacks if defined in ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.0.0] - Unreleased
 
-These are changes that will probably be included in the next release.
+> NOTICE: When migrating from a 0.2.x chart to a 0.3 chart, please take the following into account:
+
+- if you use the `env` key in your values, you should rewrite them from a
+   plain dict into a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)
 
 ### Added
 
@@ -14,6 +17,7 @@ These are changes that will probably be included in the next release.
 
 ### Changed
  * Reduce loglevel of Patroni from INFO to WARNING
+ * The values.yaml env key should be expressed as a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)s
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.0.0] - Unreleased
+## [v0.3.0] - Unreleased
 
 > NOTICE: When migrating from a 0.2.x chart to a 0.3 chart, please take the following into account:
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Add ability to [annotate](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) pods in the StatefulSet
+* Add ability to run any script as callback, if exposed as a ConfigMap
 
 ### Changed
  * Reduce loglevel of Patroni from INFO to WARNING

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-multinode
 description: 'TimescaleDB Multinode Deployment.'
-version: 0.2.4
+version: 1.0.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-multinode/Chart.yaml
+++ b/charts/timescaledb-multinode/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-multinode
 description: 'TimescaleDB Multinode Deployment.'
-version: 1.0.0
+version: 0.3.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-multinode/admin-guide.md
+++ b/charts/timescaledb-multinode/admin-guide.md
@@ -24,7 +24,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `credentials.accessNode.superuser`| Password of the superuser for the Access Node | `tea`                                             |
 | `credentials.dataNode.superuser`  | Password of the superuser for the Data Nodes  | `coffee`                                          |
-| `env`                             | Extra custom environment variables          | `PGDATA`, `LC_ALL` and `LANG`                       |
+| `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core) | `PGDATA` and some language settings |
 | `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
 | `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
 | `tolerations`                     | List of node taints to tolerate             | `[]`                                                |

--- a/charts/timescaledb-multinode/templates/statefulset-timescaledb-accessnode.yaml
+++ b/charts/timescaledb-multinode/templates/statefulset-timescaledb-accessnode.yaml
@@ -51,12 +51,9 @@ spec:
             secretKeyRef:
               name: {{ template "timescaledb.dataname" . }}
               key: password-superuser
-        {{- if .Values.env }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{  $key | quote | upper }}
-          value: {{ $val | quote }}
-        {{- end }}
-        {{- end }}
+          {{- if .Values.env }}
+{{ .Values.env | default list | toYaml | indent 8 }}
+          {{- end }}
         command:
           - sh
           - '-c'
@@ -95,12 +92,9 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        {{- if .Values.env }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{  $key | quote | upper }}
-          value: {{ $val | quote }}
-        {{- end }}
-        {{- end }}
+          {{- if .Values.env }}
+{{ .Values.env | default list | toYaml | indent 8 }}
+          {{- end }}
         ports:
         - containerPort: 5432
         volumeMounts:

--- a/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
+++ b/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
@@ -46,12 +46,9 @@ spec:
             secretKeyRef:
               name: {{ template "timescaledb.dataname" . }}
               key: password-superuser
-        {{- if .Values.env }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{  $key | quote | upper }}
-          value: {{ $val | quote }}
-        {{- end }}
-        {{- end }}
+          {{- if .Values.env }}
+{{ .Values.env | default list | toYaml | indent 8 }}
+          {{- end }}
         command:
           - sh
           - '-c'
@@ -90,12 +87,9 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        {{- if .Values.env }}
-        {{- range $key, $val := .Values.env }}
-        - name: {{  $key | quote | upper }}
-          value: {{ $val | quote }}
-        {{- end }}
-        {{- end }}
+          {{- if .Values.env }}
+{{ .Values.env | default list | toYaml | indent 8 }}
+          {{- end }}
         ports:
         - containerPort: 5432
         volumeMounts:

--- a/charts/timescaledb-multinode/values.yaml
+++ b/charts/timescaledb-multinode/values.yaml
@@ -22,13 +22,18 @@ credentials:
     superuser: coffee
 
 # Extra custom environment variables.
+# These should be an EnvVar, as this allows you to inject secrets into the environment
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
 env:
-  LC_ALL: C.UTF-8
-  LANG: C.UTF-8
-  # This should be a subdirectory of the persistentVolume (if any), as PostgreSQL will need to
-  # fully manage permissions. Also, using /var/lib/postgresql/data is discouraged, as this is
-  # a Docker Volume in many Docker images, which means the data is not actually persisted.
-  PGDATA: /var/lib/postgresql/pgdata
+  - name: LC_ALL
+    value: C.UTF-8
+  - name: LANG
+    value: C.UTF-8
+  - name: PGDATA
+    # This should be a subdirectory of the persistentVolume (if any), as PostgreSQL will need to
+    # fully manage permissions. Also, using /var/lib/postgresql/data is discouraged, as this is
+    # a Docker Volume in many Docker images, which means the data is not actually persisted.
+    value: /var/lib/postgresql/pgdata
 
 persistentVolume:
   enabled: true

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.2.5
+version: 1.0.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 1.0.0
+version: 0.3.0
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -29,7 +29,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
 | `backup.pgBackRest`               | [pgBackRest configuration](https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml)     | Working defaults |
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
-| `env`                             | Extra custom environment variables          | `{}`                                                |
+| `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
 | `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
 | `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
 | `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -58,6 +58,10 @@ Create the name of the service account to use.
 {{ printf "%s/data" .Values.persistentVolumes.data.mountPath }}
 {{- end -}}
 
+{{- define "callbacks_dir" -}}
+/etc/timescaledb/callbacks
+{{- end -}}
+
 {{- define "scripts_dir" -}}
 /etc/timescaledb/scripts
 {{- end -}}

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -58,6 +58,10 @@ Create the name of the service account to use.
 {{ printf "%s/data" .Values.persistentVolumes.data.mountPath }}
 {{- end -}}
 
+{{- define "scripts_dir" -}}
+/etc/timescaledb/scripts
+{{- end -}}
+
 {{- define "wal_directory" -}}
 {{ printf "%s/pg_wal" .Values.persistentVolumes.wal.mountPath }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -84,4 +84,16 @@ data:
 
     # We always exit 0 this script, otherwise the database initialization fails.
     exit 0
+  patroni_callback.sh: |
+    #!/bin/bash
+    set -e
+
+    for suffix in "$1" all
+    do
+      CALLBACK="{{ template "callbacks_dir" .}}/${suffix}"
+      if [ -f "${CALLBACK}" ]
+      then
+        "${CALLBACK}" $@
+      fi
+    done
 ...

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -101,12 +101,11 @@ spec:
           value: {{ printf "{app: %s, cluster-name: %s, release: %s}" (include "timescaledb.fullname" .) (include "clusterName" .) .Release.Name  | quote }}
         - name: PATRONI_SCOPE
           value: {{ template "clusterName" . }}
-        {{- range $key, $val := (.Values.env | default dict) }}
-        - name: {{  $key | quote | upper }}
-          value: {{ $val | quote }}
-        {{- end }}
         - name: PGBACKREST_CONFIG
           value: /etc/pgbackrest/pgbackrest.conf
+          {{- if .Values.env }}
+{{ .Values.env | default list | toYaml | indent 8 }}
+          {{- end }}
         ports:
         - containerPort: 8008
         - containerPort: 5432

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -136,7 +136,7 @@ spec:
           subPath: patroni.yaml
           name: patroni-config
           readOnly: true
-        - mountPath: /etc/timescaledb/scripts
+        - mountPath: {{ template "scripts_dir" . }}
           name: timescaledb-scripts
           readOnly: true
         - mountPath: /etc/certificate
@@ -157,7 +157,7 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-          - /etc/timescaledb/scripts/pgbackrest_bootstrap.sh
+          - {{ template "scripts_dir" . }}/pgbackrest_bootstrap.sh
         ports:
         - containerPort: 8081
         volumeMounts:
@@ -175,7 +175,7 @@ spec:
         - mountPath: /etc/pgbackrest
           name: pgbackrest
           readOnly: true
-        - mountPath: /etc/timescaledb/scripts
+        - mountPath: {{ template "scripts_dir" . }}
           name: timescaledb-scripts
           readOnly: true
         env:

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -143,6 +143,11 @@ spec:
           readOnly: true
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
+        {{ if .Values.callbacks.configMap -}}
+        - name: patroni-callbacks
+          mountPath: {{ template "callbacks_dir" . }}
+          readOnly: true
+        {{- end }}
 {{- if or .Values.backup.enabled .Values.backup.enable }}
         - mountPath: /etc/pgbackrest
           name: pgbackrest
@@ -234,6 +239,12 @@ spec:
         configMap:
           name: {{ template "timescaledb.fullname" . }}-scripts
           defaultMode: 488 # 0750 permissions
+      {{ if .Values.callbacks.configMap -}}
+      - name: patroni-callbacks
+        configMap:
+          name: {{ .Values.callbacks.configMap }}
+          defaultMode: 488 # 0750 permissions
+      {{- end }}
 {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         secret:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -150,7 +150,12 @@ patroni:
   postgresql:
     basebackup:
     - waldir: "/var/lib/postgresql/wal/pg_wal"
-    callbacks: {}
+    callbacks:
+      on_role_change: /etc/timescaledb/scripts/patroni_callback.sh
+      on_start: /etc/timescaledb/scripts/patroni_callback.sh
+      on_reload: /etc/timescaledb/scripts/patroni_callback.sh
+      on_restart: /etc/timescaledb/scripts/patroni_callback.sh
+      on_stop: /etc/timescaledb/scripts/patroni_callback.sh
     authentication:
       replication:
         username: standby
@@ -167,6 +172,10 @@ patroni:
     use_unix_socket: true
   restapi:
     listen: 0.0.0.0:8008
+
+callbacks:
+  # If set, this configMap will be used for the Patroni callbacks.
+  configMap: # example-patroni-callbacks
 
 loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -70,7 +70,16 @@ backup:
       schedule: "12 02 1-6 * *"
 
 # Extra custom environment variables.
-env: {}
+# These should be an EnvVar, as this allows you to inject secrets into the environment
+# https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
+env:
+#  - name: NOT_A_SECRET
+#    value: "test"
+#  - name: MYAPPLICATION_STANDBY_PASSWORDS
+#    valueFrom:
+#      secretKeyRef:
+#        name: myapplication-passwords
+#        key: standby
 
 # This configuration will be passed on to Patroni directly, there are a few things that are
 # injected/changed, these are:


### PR DESCRIPTION
There may be the need to run application specific logic after certain
events happen, e.g. database startup, database promotion etc.

To allow a pluggable way of expressing these callbacks, you can now
point to a ConfigMap which contains your callback scripts.

Keys that match any of these Patroni events:

- on_reload
- on_restart
- on_role_change
- on_start
- on_stop

Will be executed when these events happen.
An extra callback has been added for convenience which will always be
executed. (This also allows you to write a single script with some
conditional logic on the event that happened).

- all

Please refer to the Patroni manual for how these scripts should be
created and which arguments they are given:

https://patroni.readthedocs.io/en/latest/SETTINGS.html#postgresql
(look for callbacks)