### PR TITLE
Explicitly set PostgreSQL Environment Variables

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -103,6 +103,12 @@ spec:
           value: {{ template "clusterName" . }}
         - name: PGBACKREST_CONFIG
           value: /etc/pgbackrest/pgbackrest.conf
+        # PGDATA and PGHOST are not required to let Patroni/PostgreSQL run correctly,
+        # but for interactive sessions, callbacks and PostgreSQL tools they should be correct.
+        - name: PGDATA
+          value: "$(PATRONI_POSTGRESQL_DATA_DIR)"
+        - name: PGHOST
+          value: "{{ template "socket_directory" . }}"
           {{- if .Values.env }}
 {{ .Values.env | default list | toYaml | indent 8 }}
           {{- end }}


### PR DESCRIPTION
Although PGDATA and PGHOST are not directly used by Patroni and
therefore by PostgreSQL, it is very convenient to have them defined
correctly.

In the case of PGDATA, chances are high that the value was actually
exposed incorrect previously, as many PostgreSQL Docker Images set the
PGDATA environment variable explicitly. This value is very likely to be
different from the Data directory that is used in this Helm Chart - even
more so as the Data directory can be configured directly by the user of
this chart.

By overriding PGDATA explicitly with the Data Directory we also pass on
to Patroni we ensure PGDATA is correct. Some immediate advantages:

- Executing a command that may rely on PGDATA just works (think:
  pg_controldata)
- Callbacks called by Patroni have their environment setup correctly