### PR TITLE
Configure socket permissions in PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * The values.yaml env key should be expressed as a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)s
 ### Removed
 ### Fixed
+ * Set `unix_socket_permissions` using PostgreSQL parameters instead
 
 ## [v0.2.5] - 2019-11-06
 

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -230,8 +230,7 @@ spec:
     {{- end }}
       volumes:
       - name: socket-directory
-        emptyDir:
-          defaultMode: 488 # 0750 permissions
+        emptyDir: {}
       - name: patroni-config
         configMap:
           name: {{ template "timescaledb.fullname" . }}-patroni

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -128,6 +128,7 @@ patroni:
           temp_file_limit: 1GB
           timescaledb.passfile: '../.pgpass'
           unix_socket_directories: "/var/run/postgresql"
+          unix_socket_permissions: '0750'
           wal_level: hot_standby
           wal_log_hints: 'on'
           work_mem: 16MB


### PR DESCRIPTION
Previously, we attempted to restrict permissions of the socket by
setting `defaultMode` on the EmptyDir that serves the PostgreSQL socket.

This however is not a valid configuration option for EmptyDir[1], and
caused some issues when the Chart was deployed using for example Helm
2.14.0:

        Error: validation failed: error validating "":
        error validating data: ValidationError(StatefulSet.spec.template.spec.volumes[0].emptyDir):
        unknown field "defaultMode" in io.k8s.api.core.v1.EmptyDirVolumeSource

By configuring the permissions using PostgreSQL parameters we achieve
what we set out to do: protect the socket for every user, and now we
actually do it correctly.

Addresses issue #57.

1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#emptydirvolumesource-v1-core

defaultMode