### PR TITLE
Release version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.3.0] - Unreleased
+## [v0.3.0] - 2019-11-25
 
 > NOTICE: When migrating from a 0.2.x chart to a 0.3 chart, please take the following into account:
 
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Reduce loglevel of Patroni from INFO to WARNING
  * The values.yaml env key should be expressed as a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)s
-### Removed
+ * Refer to the latest minor versions for PostgreSQL & TimescaleDB
+
 ### Fixed
  * Set `unix_socket_permissions` using PostgreSQL parameters instead
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -64,13 +64,13 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 ### Examples
 - Override value using commandline parameters
     ```console
-    helm upgrade --install my-release charts/timescaledb-single --set image.tag=pg11.5-ts1.5.0 --set image.pullPolicy=Always
+    helm upgrade --install my-release charts/timescaledb-single --set image.tag=pg11.6-ts1.5.1 --set image.pullPolicy=Always
     ```
 - Override values using `myvalues.yaml`
     ```yaml
     # Filename: myvalues.yaml
     image:
-      tag: pg11.5-ts1.5.0
+      tag: pg11.6-ts1.5.1
       pullPolicy: Always
     patroni:
       postgresql:


### PR DESCRIPTION
## [v0.3.0] - 2019-11-25

> NOTICE: When migrating from a 0.2.x chart to a 0.3 chart, please take the following into account:

- if you use the `env` key in your values, you should rewrite them from a
   plain dict into a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)

### Added

* Add ability to [annotate](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) pods in the StatefulSet
* Add ability to run any script as callback, if exposed as a ConfigMap

### Changed
 * Reduce loglevel of Patroni from INFO to WARNING
 * The values.yaml env key should be expressed as a list of [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)s
 * Refer to the latest minor versions for PostgreSQL & TimescaleDB

### Fixed
 * Set `unix_socket_permissions` using PostgreSQL parameters instead

