### PR TITLE
Switch services to ClusterIP if LB is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+ These are changes that will probably be included in the next release.
+
+### Added
+### Changed
+* Switch services to ClusterIP if the Load Balancer is set to disabled
+### Removed
+### Fixed
+
 ## [v0.3.0] - 2019-11-25
 
 > NOTICE: When migrating from a 0.2.x chart to a 0.3 chart, please take the following into account:

--- a/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     cluster-name: {{ template "clusterName" . }}
+    role: replica
   annotations:
 {{ .Values.replicaLoadBalancer.annotations | toYaml | indent 4 }}
 spec:
@@ -22,7 +23,6 @@ spec:
   type: LoadBalancer
 {{- else }}
   type: ClusterIP
-  clusterIP: None
 {{- end }}
   ports:
   - name: postgresql

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     cluster-name: {{ template "clusterName" . }}
+    role: master
   annotations:
 {{ .Values.loadBalancer.annotations | toYaml | indent 4 }}
 spec:
@@ -18,7 +19,6 @@ spec:
   type: LoadBalancer
 {{- else }}
   type: ClusterIP
-  clusterIP: None
 {{- end }}
   ports:
   - name: postgresql


### PR DESCRIPTION
Previously we used a headless service if the Load Balancer (LB) was
disabled for a given service. This however runs into an issue[1] which
cannot be easily solved without having to do manually
patch/remove/update some kubernetes objects.

To allow an easy path for upgrading a non-LB service to a LB service, we
change the service from being headless to being a ClusterIP service.
This allows users of the charts to upgrade by flipping `enabled=False`
to `enabled=True` for the service they want.

Changing the service from a LoadBalancer to a ClusterIP however does not
work currently, and requires some manual steps. As we cannot currently
solve this easily in the Helm chart we document the steps that allow
this upgrade to take place.

1: https://github.com/kubernetes/kubernetes/issues/11237