### PR TITLE
Inject custom environment vars in backup container

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -171,6 +171,30 @@ backup:
 helm upgrade --install example -f myvalues.yaml charts/timescaledb-single
 ```
 
+#### Configure pgBackRest using environment variables
+Instead of configuring pgBackRest in the `myvalues.yaml`, you can also expose the configuration items as environment variables.
+This allows you to decouple the secret management of the backup credentials from this deployment.
+
+The [pgBackRest Command Reference](https://pgbackrest.org/command.html#introduction) has detailed information about which
+environment variables can be set.
+
+For example, if you would use [Vault](https://www.vaultproject.io/), you could do the following:
+
+```yaml
+# Filename: myvalues.yaml
+
+backup:
+  enabled: True
+    pgBackRest:
+      repo1-s3-bucket: this_bucket_may_not_exist
+  env:
+    - name: PGBACKREST_REPO1_S3_KEY
+      value: vault:secret/data/my-system/mydb#PGBACKREST_REPO1_S3_KEY
+    - name: PGBACKREST_REPO1_S3_KEY_SECRET
+      value: vault:secret/data/my-system/mydb#PGBACKREST_REPO1_S3_KEY_SECRET
+```
+
+
 ### Control the backup schedule
 If you want to alter the backup jobs, or their schedule, you can override the `backup.jobs` in your configuration, for example:
 

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -112,6 +112,13 @@ spec:
           {{- if .Values.env }}
 {{ .Values.env | default list | toYaml | indent 8 }}
           {{- end }}
+          # pgBackRest is also called using the archive_command if the backup is enabled.
+          # this script will also need access to the environment variables specified for
+          # the backup. This can be removed once we do not directly invoke pgBackRest
+          # from inside the TimescaleDB container anymore
+          {{- if .Values.backup.env }}
+{{ .Values.backup.env | default list | toYaml | indent 8 }}
+          {{- end }}
         ports:
         - containerPort: 8008
         - containerPort: 5432
@@ -195,6 +202,9 @@ spec:
             value: poddb
           - name: PGBACKREST_CONFIG
             value: /etc/pgbackrest/pgbackrest.conf
+          {{- if .Values.backup.env }}
+{{ .Values.backup.env | default list | toYaml | indent 10 }}
+          {{- end }}
 {{ end }}
 
 {{- if .Values.prometheus.enabled }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -56,6 +56,8 @@ backup:
     repo1-cipher-type: "none"
     # These secrets should contain an IAM access key ID and a secret access key:
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html
+    # These can also be specified as EnvVars below, which allows you to refer to k8s
+    # secrets or other secret injection mechanisms
     repo1-s3-key: examplekeyid
     repo1-s3-key-secret: examplesecret+D48GXfDdtl823nlSRRv7dmB
   jobs:
@@ -68,6 +70,17 @@ backup:
     - name: incremental-daily
       type: incr
       schedule: "12 02 1-6 * *"
+  # Extra custom environment variables for prometheus.
+  # These should be an EnvVar, as this allows you to inject secrets into the environment
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
+  env:
+  #- name: PGBACKREST_REPO1_S3_KEY
+  #  value: examplekeyid
+  #- name: PGBACKREST_REPO1_S3_KEY_SECRET
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: pgbackrest-dev-secrets
+  #      key: repo1-s3-key-secret
 
 # Extra custom environment variables.
 # These should be an EnvVar, as this allows you to inject secrets into the environment


### PR DESCRIPTION
- [X] Inject env vars in pgBackRest container
- [x] ~~use `vault-env` to start postgres and pgBackRest~~ This will be for another PR
- [x] adequate documentation

This allows us to start to remove some secrets from the provided values,
which is something we've been asked a few times already.