### PR TITLE
Make Prometheus scrapeable and add more config

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -209,11 +209,17 @@ spec:
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
           readOnly: true
+          {{- if .Values.prometheus.volumeMounts }}
+{{ .Values.prometheus.volumeMounts | default list | toYaml | indent 8 }}
+          {{- end }}
         env:
-          - name: DATA_SOURCE_NAME
-            value: "host={{ template "socket_directory" . }} user=postgres application_name=postgres_exporter"
-          - name: PG_EXPORTER_CONSTANT_LABELS
-            value: release={{ .Release.Name }},namespace={{ .Release.Namespace }}
+        - name: DATA_SOURCE_NAME
+          value: "host={{ template "socket_directory" . }} user=postgres application_name=postgres_exporter"
+        - name: PG_EXPORTER_CONSTANT_LABELS
+          value: release={{ .Release.Name }},namespace={{ .Release.Namespace }}
+          {{- if .Values.prometheus.env }}
+{{ .Values.prometheus.env | default list | toYaml | indent 8 }}
+          {{- end }}
 {{ end }}
 
     {{- with .Values.nodeSelector }}
@@ -263,6 +269,9 @@ spec:
       {{- if not .Values.persistentVolumes.data.enabled }}
       - name: storage-volume
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.prometheus.volumes }}
+{{ .Values.prometheus.volumes | toYaml | indent 6 }}
       {{- end }}
   volumeClaimTemplates:
   {{- if .Values.persistentVolumes.data.enabled }}

--- a/charts/timescaledb-single/templates/svc-prometheus.yaml
+++ b/charts/timescaledb-single/templates/svc-prometheus.yaml
@@ -1,0 +1,21 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+#
+# This service is only created if Prometheus is enabled.
+{{ if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "clusterName" . }}-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+spec:
+  ports:
+    - port: 9187
+  selector:
+    app: {{ template "timescaledb.fullname" . }}
+{{ end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -264,6 +264,33 @@ prometheus:
     repository: wrouesnel/postgres_exporter
     tag: v0.7.0
     pullPolicy: IfNotPresent
+  # Extra custom environment variables for prometheus.
+  # These should be an EnvVar, as this allows you to inject secrets into the environment
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
+  env:
+  #- name: NOT_A_SECRET
+  #  value: "test"
+  #- name: MYAPPLICATION_STANDBY_PASSWORDS
+  #  valueFrom:
+  #    secretKeyRef:
+  #      name: myapplication-passwords
+  #      key: standby
+  # Additional volumes for prometheus, e.g., to support additional queries.
+  # These should be a Volume, as this allows you to inject any kind of Volume
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core
+  volumes:
+  #- name: exporter-config
+  #  configMap:
+  #    name: exporter-prometheus
+  #    items:
+  #      - key: metrics_queries
+  #        path: queries.yaml
+  # Additional volume mounts, to be used in conjunction with the above variable.
+  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core
+  volumeMounts:
+  #- name: exporter-config
+  #  mountPath: /var/exporter
+
 
 # Annotations that are applied to each pod in the stateful set
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
Previously, even if you enabled Prometheus support, it was not
scrapeable because there was no service with the appropriate
annotations to tell Prometheus how to find it. To fix this, we now
deploy a service if Prometheus is enabled.

Further, to support more configuration of the Prometheus Postgres
exporter, we add the ability to specify env vars for specifically
the exporter container as well as volumes. This allows one to do
things like add custom queries to have their results exported with
other Prometheus metrics.