### PR TITLE
Create directories before restore if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 * Switch services to ClusterIP if the Load Balancer is set to disabled
+* Create PGDATA and WALDIR before a pgBackRest restore
 ### Removed
 ### Fixed
 

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -59,7 +59,16 @@ data:
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 1
 
-    pgbackrest --stanza=poddb --delta --log-level-console=detail restore
+    PGDATA={{ include "data_directory" . | quote }}
+    WALDIR={{ include "wal_directory" . | quote }}
+
+    # A missing PGDATA points to Patroni removing a botched PGDATA, or manual
+    # intervention. In this scenario, we need to recreate the DATA and WALDIRs
+    # to keep pgBackRest happy
+    [ -d "${PGDATA}" ] || install -o postgres -g postgres -d -m 0700 "${PGDATA}"
+    [ -d "${WALDIR}" ] || install -o postgres -g postgres -d -m 0700 "${WALDIR}"
+
+    pgbackrest --stanza=poddb --force --delta --log-level-console=detail restore
   post_init.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}


### PR DESCRIPTION
In some scenario's it can be that the PGDATA directory is missing,
Patroni will remove the PGDATA directory for example if it is unable to
bootstrap a replica correctly.

When this situation occurs, pgBackRest will refuse to commence the
restore with the following error message:

        ERROR: [073]: $PGDATA directory '/var/lib/postgresql/data' does not exist

Even though this can happen, it is not the normal sequence of events:
the PGDATA directory is explicitly created on container start.

If PGDATA does not exist it has to have been either Patroni or a (human)
operator that has removed this directory.

If Patroni removes PGDATA, it will also remove the WALDIR[1], and therefore
we will also have to recreate that sometimes.

1: https://github.com/zalando/patroni/blob/v1.6.3/patroni/postgresql/__init__.py#L782-L789