### PR TITLE
Add support for NetworkPolicies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  These are changes that will probably be included in the next release.
 
 ### Added
+* Enabling Prometheus now creates a Service that can be properly scraped
+* Support for NetworkPolicy
 ### Changed
 * Switch services to ClusterIP if the Load Balancer is set to disabled
 * Create PGDATA and WALDIR before a pgBackRest restore

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -42,6 +42,9 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
+| `networkPolicy.enabled`           | If enabled, creates a NetworkPolicy for controlling network access | `false`
+| `networkPolicy.ingress`           | A list of Ingress rules to extend the base NetworkPolicy | `nil`
+| `networkPolicy.prometheusApp`     | Name of Prometheus app to allow it to scrape exporters | `prometheus`
 | `replicaLoadBalancer.enabled`     | If enabled, creates a LB for replica's only | `false`                                             |
 | `replicaLoadBalancer.annotations` | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |

--- a/charts/timescaledb-single/templates/networkpolicy.yaml
+++ b/charts/timescaledb-single/templates/networkpolicy.yaml
@@ -1,0 +1,42 @@
+{{ if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "clusterName" . }}-policy
+  app: {{ template "timescaledb.fullname" . }}
+  chart: {{ template "timescaledb.chart" . }}
+  release: {{ .Release.Name }}
+  heritage: {{ .Release.Service }}
+  cluster-name: {{ template "clusterName" . }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "timescaledb.fullname" . }}
+  ingress:
+    # Replicas and master need to communicate: 5432 for PG/replication,
+    # 8008 is Patroni's race for broadcast, and 8081 is for backups.
+    - from:
+      - podSelector:
+          matchLabels:
+            app: {{ template "timescaledb.fullname" . }}
+      ports:
+      - port: 5432
+        protocol: TCP
+      - port: 8008
+        protocol: TCP
+      - port: 8081
+        protocol: TCP
+    {{ if .Values.prometheus.enabled }}
+    # Prom server for scraping exporter
+    - from:
+      - podSelector:
+          matchLabels:
+            app: {{ .Values.networkPolicy.prometheusApp }}
+      ports:
+        - protocol: TCP
+          port: 9187
+    {{ end }}
+    {{- if .Values.networkPolicy.ingress }}
+{{ .Values.networkPolicy.ingress | default list | toYaml | indent 4 }}
+    {{- end }}
+{{ end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -276,6 +276,20 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+networkPolicy:
+  enabled: False
+  prometheusApp: prometheus
+  # Below you can specify a whitelist of Ingress rules, for more information:
+  # https://kubernetes.io/docs/concepts/services-networking/network-policies/#the-networkpolicy-resource
+  ingress:
+  #- from:
+  #  - podSelector:
+  #      matchLabels:
+  #        app: foo
+  #  ports:
+  #    - protocol: TCP
+  #      port: 11111
+
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 


### PR DESCRIPTION
For Kubernetes clusters that make use of NetworkPolicy and CNI, we
should provide a basic policy that they can extend with additional
rules.

To that end, this PR adds support for such a policy that makes sure
that all pods within the app can talk to one another (i.e. for
replication), can talk on the Patroni multicast channel for leader
races, and can communicate with backup scripts. Additionally, we
also have an ingress rule to allow Prometheus scrapers to connect
to the Prometheus endpoints. These ingress rules can be extended
by setting new rules under the 'networkPolicy.ingress' variable.