### PR TITLE
Fail fast on datadir or waldir issues

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -49,7 +49,7 @@ spec:
           # set the permissons of these directories before we hand over to Patroni
           - |
             {{ .Values.debug.execStartPre }}
-            install -o postgres -g postgres -d -m 0700 {{ include "data_directory" . | quote }} {{ include "wal_directory" . | quote }}
+            install -o postgres -g postgres -d -m 0700 {{ include "data_directory" . | quote }} {{ include "wal_directory" . | quote }} || exit 1
             exec patroni /etc/timescaledb/patroni.yaml
         env:
         # We use mixed case environment variables for Patroni User management,


### PR DESCRIPTION
The install command should not fail if permissions are correct or if the
directories already exist. As a failure on the data directory or the wal
directory will also cause Patroni and PostgreSQL to fail, it seems
better to fail fast with the error message rather than to continue,
which will clutter the logs with more error messages.

For example in issue #72, the output would have been very clear that it
is a permission problem.