### PR TITLE
Update Patroni DCS Configuration on Helm Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  These are changes that will probably be included in the next release.
 
+## [v0.5.0] - To be determined
+
+> NOTICE: When migrating from a < 0.5.x chart, the primary Service needs to be removed before
+> invoking `helm update`, as the update will otherwise fail.
+
 ### Added
  * Optionally tune PostgreSQL settings (e.g. shared\_buffers, work\_mem, max\_wal\_size) using timescaledb-tune
 ### Changed
+ * The Service for the primary is now also created and managed by Helm
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * The Service for the primary is now also created and managed by Helm
 ### Removed
 ### Fixed
+ * Configuration changes in `patroni.bootstrap.dcs` now propagates to PostgreSQL servers, previously these settings
+   were only read during bootstrap.
 
 ## [v0.4.0] - 2019-12-12
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -127,17 +127,16 @@ my-release-replica   ClusterIP      None            <none>                     5
 
 ## Cleanup
 
-Removing a deployment can be done by deleting a Helm deployment, however, removing the deployment does not remove:
-- the Persistent Volume Claims (pvc) belonging to the cluster
-- or the headless service that is used by Patroni for its configuration
+Removing a deployment can be done by deleting a Helm deployment, however, removing the deployment does not remove
+the Persistent Volume Claims (pvc) belonging to the cluster.
 
 To fully purge a deployment in Kubernetes, you should do the following:
 ```console
 # Delete the Helm deployment
 helm delete my-release
-# Delete pvc and the headless Patroni service and the endpoints
+# Delete pvc 
 RELEASE=my-release
-kubectl delete $(kubectl get pvc,service,endpoints -l release=$RELEASE -o name)
+kubectl delete $(kubectl get pvc -l release=$RELEASE -o name)
 ```
 
 ### Optional: Delete the s3 backups

--- a/charts/timescaledb-single/templates/job-update-patroni.yaml
+++ b/charts/timescaledb-single/templates/job-update-patroni.yaml
@@ -1,0 +1,56 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+{{/*
+The sole purpose of this job is to trigger Patroni to rewrite the
+Dynamic Configuration[1] in the DCS.
+
+As the configuration may change between every invocation of Helm, we
+need to run this trigger after every update.
+
+To prevent Helm failing to update a deployment, we add some random characters
+to the created job; Helm cannot create a job with the same name,
+however, (completed) jobs will not immediately be removed by Kubernetes.
+
+1: https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
+*/}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-patroni-{{ randAlphaNum 2 | lower }}"
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+    chart: {{ template "timescaledb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster-name: {{ template "clusterName" . }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  activeDeadlineSeconds: 60
+  template:
+    metadata:
+      labels:
+        app: {{ template "timescaledb.fullname" . }}
+        chart: {{ template "timescaledb.chart" . }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+        cluster-name: {{ template "clusterName" . }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: {{ template "timescaledb.fullname" . }}-patch-patroni-config
+        image: curlimages/curl
+        command: ["/usr/bin/curl"]
+        args:
+        - --connect-timeout
+        - '10'
+        - --include
+        - --silent
+        - --show-error
+        - --fail
+        - --request
+        - PATCH
+        - --data
+        - {{ .Values.patroni.bootstrap.dcs | toJson | quote }}
+        - "http://{{ $.Release.Name }}-config:8008/config"

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -87,7 +87,7 @@ spec:
               fi
 
               touch "${TSTUNE_FILE}"
-              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" {{ .Values.timescaledbTune.args | join " " }} -yes
+              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" -yes
 
               # If there is a dedicated WAL Volume, we want to set max_wal_size to 80% of that volume
               # If there isn't a dedicated WAL Volume, we set it to 20% of the data volume

--- a/charts/timescaledb-single/templates/svc-timescaledb-config.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-config.yaml
@@ -1,0 +1,37 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+{{/*
+This service allows internal connections to the Patroni Api.
+
+The current implementation does not protect this API endpoint,
+therefore we do not want it to be exposed together with
+the PostgreSQL service (every client would then be able to
+reconfigure Patroni).
+
+This Service would have been created by Patroni if it would
+not be part of this Helm Chart. The only thing we do here
+is to add the labels, selector and port. The underlying Endpoints
+is used by Patroni to store the configuration.
+
+https://patroni.readthedocs.io/en/latest/rest_api.html
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "clusterName" . }}-config
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+    chart: {{ template "timescaledb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster-name: {{ template "clusterName" . }}
+spec:
+  selector:
+    app: {{ template "timescaledb.fullname" . }}
+    cluster-name: {{ template "clusterName" . }}
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: patroni
+    port: 8008
+    protocol: TCP


### PR DESCRIPTION

# Update Patroni DCS Configuration on Helm Update

Previously, changes in the `patroni.bootstrap.dcs` section of the
values.yaml would not propagate anywhere, as this section is only read
once (during initdb time), and then persisted in the DCS.

The documented way to update the dynamic configuration[1] is to:

1. update the DCS directly (kubectl edit ep/RELEASE-config)
2. or to send a PATCH to the /config endpoint[2] of Patroni

This commit implements option 2; it will connect to any running Patroni
to PATCH the config endpoint, for every update of the Helm Deployment.

The downside of option 1 is that it tries us to the DCS directly, whereas
Patroni can also use a separate etcd, consul etc, instead of relying on
Kubernetes endpoints.

1: https://patroni.readthedocs.io/en/latest/dynamic_configuration.html
2: https://patroni.readthedocs.io/en/latest/rest_api.html#config-endpoint

This addresses Issue #74

#  Expose Patroni through the -config Service

Previously this Service would have been created by Patroni and would be
created without a Selector. After this commit, this (headless) service allows
connections to the Patroni port.

As a side effect, this will also remove the -config Service and
Endpoints due to the Helm annotations, this means less work when purging
a deployment from Kubernetes.
