### PR TITLE
Run timescaledb-tune at pod initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  These are changes that will probably be included in the next release.
 
 ### Added
+ * Optionally tune PostgreSQL settings (e.g. shared\_buffers, work\_mem, max\_wal\_size) using timescaledb-tune
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `rbac.create`                     | Create required role and rolebindings       | `true`                                              |
 | `serviceAccount.create`           | If true, create a new service account       | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |
+| `timescaledbTune.enabled`         | If true, runs `timescaledb-tune` before starting PostgreSQL | `false`                             |
 
 ### Examples
 - Override value using commandline parameters

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Create the name of the service account to use.
 {{- end -}}
 
 {{- define "socket_directory" -}}
-/var/run/postgresql/
+/var/run/postgresql
 {{- end -}}
 
 {{- define "data_directory" -}}
@@ -68,4 +68,8 @@ Create the name of the service account to use.
 
 {{- define "wal_directory" -}}
 {{ printf "%s/pg_wal" .Values.persistentVolumes.wal.mountPath }}
+{{- end -}}
+
+{{- define "tstune_config" -}}
+{{ printf "%s/timescaledb.conf" (include "socket_directory" .) }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -89,6 +89,7 @@ data:
 
     log "Invoking initdb"
     initdb --auth-local=peer --auth-host=md5 --pgdata="${PGDATA}" --waldir="${WALDIR}" ${initdb_args}
+    echo "include_if_exists = '{{ template "tstune_config". }}'" >> "${PGDATA}/postgresql.conf"
 
   post_init.sh: |
     #!/bin/bash

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -69,6 +69,27 @@ data:
     [ -d "${WALDIR}" ] || install -o postgres -g postgres -d -m 0700 "${WALDIR}"
 
     pgbackrest --stanza=poddb --force --delta --log-level-console=detail restore
+  restore_or_initdb.sh: |
+    #!/bin/bash
+
+    function log {
+      echo "$(date '+%Y-%m-%d %H:%M:%S') - restore_or_initdb - $1"
+    }
+
+    PGDATA={{ include "data_directory" . | quote }}
+    WALDIR={{ include "wal_directory" . | quote }}
+
+    # Patroni attaches --scope and --datadir to the arguments, we need to strip them off as
+    # initdb has no business with these parameters
+    initdb_args=""
+    for value in "$@"
+    do
+      [[ $value == --scope* ]] || [[ $value == --datadir* ]] || initdb_args="${initdb_args} $value"
+    done
+
+    log "Invoking initdb"
+    initdb --auth-local=peer --auth-host=md5 --pgdata="${PGDATA}" --waldir="${WALDIR}" ${initdb_args}
+
   post_init.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -37,6 +37,83 @@ spec:
         # The postgres user inside the TimescaleDB image has uid=1000.
         # This configuration ensures the permissions of the mounts are suitable
         fsGroup: 1000
+{{- if .Values.timescaledbTune.enabled }}
+      initContainers:
+      - name: tstune
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        env:
+        - name: TSTUNE_FILE
+          value: {{ template "tstune_config" . }}
+        - name: RESOURCES_WAL_VOLUME
+          value: {{ if .Values.persistentVolumes.wal.enabled }}{{ .Values.persistentVolumes.wal.size }}{{ else }}"0"{{ end }}
+        - name: RESOURCES_DATA_VOLUME
+          value: {{ .Values.persistentVolumes.data.size }}
+        - name: INCLUDE_DIRECTIVE
+          value: include_if_exists = '{{ template "tstune_config" . }}'
+        - name: CPUS
+          valueFrom:
+            resourceFieldRef:
+              containerName: timescaledb
+              resource: requests.cpu
+              divisor: "1"
+        - name: MEMORY
+          valueFrom:
+            resourceFieldRef:
+              containerName: timescaledb
+              resource: requests.memory
+              divisor: 1Mi
+        - name: RESOURCES_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: timescaledb
+              resource: limits.cpu
+              divisor: "1"
+        - name: RESOURCES_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              containerName: timescaledb
+              resource: limits.memory
+              divisor: 1Mi
+        command:
+          - sh
+          - "-c"
+          - |
+              set -e
+              [ $CPUS -eq 0 ]   && CPUS="${RESOURCES_CPU_LIMIT}"
+              [ $MEMORY -eq 0 ] && MEMORY="${RESOURCES_MEMORY_LIMIT}"
+
+              if [ -f "${PGDATA}/postgresql.base.conf" ] && ! grep "${INCLUDE_DIRECTIVE}" postgresql.base.conf -qxF; then
+                echo "${INCLUDE_DIRECTIVE}" >> "${PGDATA}/postgresql.base.conf"
+              fi
+
+              touch "${TSTUNE_FILE}"
+              timescaledb-tune -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" -yes
+
+              # If there is a dedicated WAL Volume, we want to set max_wal_size to 80% of that volume
+              # If there isn't a dedicated WAL Volume, we set it to 20% of the data volume
+              if [ "${RESOURCES_WAL_VOLUME}" = "0" ]; then
+                WALMAX="${RESOURCES_DATA_VOLUME}"
+                WALMAXMULTIPLIER=20
+              else
+                WALMAX="${RESOURCES_WAL_VOLUME}"
+                WALMULTIPLIER=80
+              fi
+
+              WALMAX=$(numfmt --from=auto ${WALMAX})
+
+              # Wal segments are 16MB in size, in this way we get a "nice" number of the nearest
+              # 16MB
+              WALMAX=$(( $WALMAX / 100 * $WALMULTIPLIER / 16777216 * 16 ))
+              WALMIN=$(( $WALMAX / 2 ))
+
+              echo "max_wal_size=${WALMAX}MB" >> "${TSTUNE_FILE}"
+              echo "min_wal_size=${WALMIN}MB" >> "${TSTUNE_FILE}"
+
+              cat "${TSTUNE_FILE}"
+        volumeMounts:
+        - name: socket-directory
+          mountPath: {{ template "socket_directory" . }}
+{{- end }}
       containers:
       - name: timescaledb
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -37,8 +37,8 @@ spec:
         # The postgres user inside the TimescaleDB image has uid=1000.
         # This configuration ensures the permissions of the mounts are suitable
         fsGroup: 1000
-{{- if .Values.timescaledbTune.enabled }}
       initContainers:
+{{- if .Values.timescaledbTune.enabled }}
       - name: tstune
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         env:
@@ -87,29 +87,27 @@ spec:
               fi
 
               touch "${TSTUNE_FILE}"
-              timescaledb-tune -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" -yes
+              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" {{ .Values.timescaledbTune.args | join " " }} -yes
 
               # If there is a dedicated WAL Volume, we want to set max_wal_size to 80% of that volume
               # If there isn't a dedicated WAL Volume, we set it to 20% of the data volume
               if [ "${RESOURCES_WAL_VOLUME}" = "0" ]; then
                 WALMAX="${RESOURCES_DATA_VOLUME}"
-                WALMAXMULTIPLIER=20
+                WALPERCENT=20
               else
                 WALMAX="${RESOURCES_WAL_VOLUME}"
-                WALMULTIPLIER=80
+                WALPERCENT=80
               fi
 
               WALMAX=$(numfmt --from=auto ${WALMAX})
 
               # Wal segments are 16MB in size, in this way we get a "nice" number of the nearest
               # 16MB
-              WALMAX=$(( $WALMAX / 100 * $WALMULTIPLIER / 16777216 * 16 ))
+              WALMAX=$(( $WALMAX / 100 * $WALPERCENT / 16777216 * 16 ))
               WALMIN=$(( $WALMAX / 2 ))
 
               echo "max_wal_size=${WALMAX}MB" >> "${TSTUNE_FILE}"
               echo "min_wal_size=${WALMIN}MB" >> "${TSTUNE_FILE}"
-
-              cat "${TSTUNE_FILE}"
         volumeMounts:
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -297,6 +297,10 @@ networkPolicy:
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+# https://github.com/timescale/timescaledb-tune
+timescaledbTune:
+  enabled: False
+
 # Prometheus exporter for PostgreSQL server metrics.
 # https://github.com/wrouesnel/postgres_exporter
 prometheus:

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -123,7 +123,6 @@ patroni:
           autovacuum_analyze_scale_factor: 0.02
           autovacuum_max_workers: 10
           autovacuum_vacuum_scale_factor: 0.05
-          checkpoint_completion_target: 0.99
           hot_standby: 'on'
           log_autovacuum_min_duration: 0
           log_checkpoints: 'on'
@@ -135,11 +134,6 @@ patroni:
           log_statement: ddl
           max_connections: 100
           max_prepared_transactions: 150
-          # These values are set small as the default data volume size
-          # is small as well.
-          max_wal_size: 750MB
-          min_wal_size: 250MB
-          shared_buffers: 300MB
           shared_preload_libraries: timescaledb,pg_stat_statements
           ssl: 'on'
           ssl_cert_file: '/etc/certificate/tls.crt'
@@ -152,7 +146,6 @@ patroni:
           unix_socket_permissions: '0750'
           wal_level: hot_standby
           wal_log_hints: 'on'
-          work_mem: 16MB
         use_pg_rewind: true
         use_slots: true
       retry_timeout: 10
@@ -262,9 +255,8 @@ persistentVolumes:
     enabled: True
     size: 1Gi
     subPath: ""
-    # When changing this mountPath ensure you also change the following keys to reflect this:
-    # patroni->bootstrap->initdb (waldir option)
-    # patroni->postgresql-basebackup (waldir option)
+    # When changing this mountPath ensure you also change the following key to reflect this:
+    # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
     annotations: {}
     accessModes:
@@ -279,6 +271,13 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# timescaledb-tune will be run with the Pod resources requests or - if not set - its limits.
+# This should give a reasonably tuned PostgreSQL instance.
+# Any PostgreSQL parameter that is explicitly set in the Patroni configuration will override
+# the auto-tuned variables.
+timescaledbTune:
+  enabled: False
 
 networkPolicy:
   enabled: False
@@ -296,10 +295,6 @@ networkPolicy:
 
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
-
-# https://github.com/timescale/timescaledb-tune
-timescaledbTune:
-  enabled: False
 
 # Prometheus exporter for PostgreSQL server metrics.
 # https://github.com/wrouesnel/postgres_exporter

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -102,7 +102,15 @@ env:
 patroni:
   log:
     level: WARNING
+  # https://patroni.readthedocs.io/en/latest/replica_bootstrap.html#bootstrap
   bootstrap:
+    method: restore_or_initdb
+    restore_or_initdb:
+      command: >
+        /etc/timescaledb/scripts/restore_or_initdb.sh
+        --encoding=UTF8
+        --locale=C.UTF-8
+      keep_existing_recovery_conf: True
     post_init: /etc/timescaledb/scripts/post_init.sh
     dcs:
       loop_wait: 10
@@ -149,10 +157,6 @@ patroni:
         use_slots: true
       retry_timeout: 10
       ttl: 30
-    initdb:
-    - encoding: UTF8
-    - locale: C.UTF-8
-    - waldir: "/var/lib/postgresql/wal/pg_wal"
   kubernetes:
     role_label: role
     scope_label: cluster-name


### PR DESCRIPTION
# Tune pod using timescaledb-tune

To ensure timescaledb-tune works well with a Patroni managed PostgreSQL
instance, we create a separate configuration file which is fully
generated by timescaledb.
We will then use the include directive of PostgreSQL configuration files
to load this file.

This means the order of evaluation of settings becomes as follows:

1. PostgreSQL compiled defaults
2. postgresql.example.conf from the package
3. timescaledb-tune generated file
4. Patroni: bootstrap.dcs.postgresql.parameters
5. Patroni: postgresql.parameters
6: Patroni: overrides (cluster-name for example)

This means that if `shared_buffers`, is not specified in the Patroni
configuration it will use the value of timescaledb-tune.

Timescaledb-tune is currently not very well suited to set min/max wal
size, so in order to tune those we do some shell arithmetic.

Disabled this feature by default, to allow some evaluation to take
place.

# Use custom bootstrap method instead of initdb

We need more control on how the PGDATA directory is initialized before
it is handed over to Patroni.

A few things we want to implement:

- Backup from restore if there is a backup
- Inject an 'include_if_exists' for a file generated by timescaledb-tune

This commit only introduces the wrapper to make these things possible,
the result is the same as before.
