### PR TITLE
Pass on arguments to timescaledb-tune

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -87,7 +87,8 @@ spec:
               fi
 
               touch "${TSTUNE_FILE}"
-              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" -yes
+              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" \
+                {{ range $key, $value := .Values.timescaledbTune.args | default dict }}{{ printf "--%s %s " $key (quote $value)}}{{ end }} -yes
 
               # If there is a dedicated WAL Volume, we want to set max_wal_size to 80% of that volume
               # If there isn't a dedicated WAL Volume, we set it to 20% of the data volume

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -278,6 +278,16 @@ resources: {}
 # the auto-tuned variables.
 timescaledbTune:
   enabled: False
+  # For full flexibility, we allow you to override any timescaledb-tune parameter below.
+  # However, these parameters only take effect on newly scheduled pods and their settings are
+  # only visibible inside those new pods.
+  # Therefore you probably want to set explicit overrides in patroni.bootstrap.dcs.postgresql.parameters,
+  # as those will take effect as soon as possible.
+  # https://github.com/timescale/timescaledb-tune
+  args: {}
+    # max-conns: 120
+    # cpus: 5
+    # memory: 4GB
 
 networkPolicy:
   enabled: False


### PR DESCRIPTION
To allow full flexibility of the timescaledb-tune process, we pass on
all arguments defined in the values.yaml.