### PR TITLE
Grant permissions to endpoints/restricted

### DIFF
--- a/charts/timescaledb-single/templates/role-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/role-timescaledb.yaml
@@ -28,7 +28,9 @@ rules:
   verbs:
   - create
 - apiGroups: [""]
-  resources: ["endpoints"]
+  resources:
+  - endpoints
+  - endpoints/restricted
   verbs:
   - create
   - get


### PR DESCRIPTION
For OpenShift explicit permissions for endpoints are required.

https://docs.openshift.com/container-platform/3.6/architecture/core_concepts/pods_and_services.html#endpoints

Addresses issue #91