### PR TITLE
Only verify backup stanza when running as a primary

### DIFF
--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -47,10 +47,13 @@ data:
         sleep 3
     done
 
-    pgbackrest check || {
-        log "Creating pgBackrest stanza"
-        pgbackrest --stanza=poddb stanza-create --log-level-stderr=info || exit 1
-    }
+    # If we are the primary, we want to create/validate the backup stanza
+    if [ "$(psql -c "SELECT pg_is_in_recovery()::text" -AtXq)" == "false" ]; then
+        pgbackrest check || {
+            log "Creating pgBackrest stanza"
+            pgbackrest --stanza=poddb stanza-create --log-level-stderr=info || exit 1
+        }
+    fi
 
     log "Starting pgBackrest api to listen for backup requests"
     exec python3 /scripts/pgbackrest-rest.py --stanza=poddb --loglevel=debug


### PR DESCRIPTION
The check command of pgBackRest used to succeed on the replica, but this
behaviour changed recently [1] and will be ok in the long term.

This commit is a workaround for this change, and will only check the
backup stanza when running as primary.

Addresses issues #83 and #93

1: https://github.com/pgbackrest/pgbackrest/issues/878