### PR TITLE
Update default cron schedules for backups

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -66,10 +66,10 @@ backup:
       # schedule: https://en.wikipedia.org/wiki/Cron#CRON_expression
     - name: full-weekly
       type: full
-      schedule: "00 02 * * 0"
+      schedule: "12 02 * * 0"
     - name: incremental-daily
       type: incr
-      schedule: "00 02 * * 1-6"
+      schedule: "12 02 * * 1-6"
   # Extra custom environment variables for prometheus.
   # These should be an EnvVar, as this allows you to inject secrets into the environment
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -66,10 +66,10 @@ backup:
       # schedule: https://en.wikipedia.org/wiki/Cron#CRON_expression
     - name: full-weekly
       type: full
-      schedule: "12 02 7 * *"
+      schedule: "00 02 * * 0"
     - name: incremental-daily
       type: incr
-      schedule: "12 02 1-6 * *"
+      schedule: "00 02 * * 1-6"
   # Extra custom environment variables for prometheus.
   # These should be an EnvVar, as this allows you to inject secrets into the environment
   # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core


### PR DESCRIPTION
DOM & DOW positions appear to be mixed up.

To verify based on a compliant cron syntax:
`00 02 * * 0`: [0200 every Sunday](https://crontab.guru/#00_02_*_*_0)
`00 02 * * 1-6`: [0200 every day-of-week from Monday through Saturday](https://crontab.guru/#00_02_*_*_1-6)