### PR TITLE
Fix JSON formatting for backup cronjob

### DIFF
--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -75,7 +75,7 @@ spec:
               - POST
               - --data
               - |
-                  {"type": {{ quote .type }}
+                  {"type": {{ quote .type }}}
               - "http://{{ template "timescaledb.fullname" $ }}-backup:8081/backups/"
 ...
 {{- end }}


### PR DESCRIPTION
Fix #100 

Helm template output
```
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: timescaledb-incremental-daily
  labels:
    app: timescaledb
    chart: timescaledb-single-0.5.1
    release: timescaledb
    heritage: Tiller
    backup-type: incr
    cluster-name: timescaledb
spec:
  schedule: "12 02 * * 1-6"
  concurrencyPolicy: Forbid
  jobTemplate:
    metadata:
      labels:
        app: timescaledb
        chart: timescaledb-single-0.5.1
        release: timescaledb
        heritage: Tiller
        backup-type: incr
        cluster-name: timescaledb
    spec:
      activeDeadlineSeconds: 60
      template:
        metadata:
          labels:
            app: timescaledb
            chart: timescaledb-single-0.5.1
            release: timescaledb
            heritage: Tiller
            backup-type: incr
            cluster-name: timescaledb
        spec:
          restartPolicy: OnFailure
          containers:
            - name: timescaledb-incr
              image: curlimages/curl
              command: ["/usr/bin/curl"]
              args:
              - --connect-timeout
              - '10'
              - --include
              - --silent
              - --show-error
              - --fail
              - --request
              - POST
              - --data
              - |
                  {"type": "incr"}
              - "http://timescaledb-backup:8081/backups/"
```
