### PR TITLE
Add tablespace support during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  These are changes that will probably be included in the next release.
 ### Added
+ * Support for multiple tablespaces at initialization time
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `persistentVolumes.<name>.size`   | Persistent Volume size                      | `2Gi`                                               |
 | `persistentVolumes.<name>.storageClass`| Persistent Volume Storage Class        | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolumes.<name>.subPath`| Subdirectory of Persistent Volume to mount  | `""`                                                |
+| `persistentVolumes.tablespaces`   | A mapping of tablespaces and Volumes        | `nil`, see [multiple-tablespaces.yaml](values/multiple-tablespaces.yaml) for a full example |
 | `rbac.create`                     | Create required role and rolebindings       | `true`                                              |
 | `serviceAccount.create`           | If true, create a new service account       | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -62,6 +62,10 @@ Create the name of the service account to use.
 /etc/timescaledb/callbacks
 {{- end -}}
 
+{{- define "tablespaces_dir" -}}
+{{ printf "%s/tablespaces" .Values.persistentVolumes.data.mountPath }}
+{{- end -}}
+
 {{- define "scripts_dir" -}}
 /etc/timescaledb/scripts
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -114,6 +114,17 @@ data:
       CREATE EXTENSION timescaledb;
     __SQL__
 
+    TABLESPACES={{ $.Values.persistentVolumes.tablespaces | default dict | keys | join " " | quote }}
+    for tablespace in $TABLESPACES
+    do
+      log "Creating tablespace ${tablespace}"
+      tablespacedir="{{ include "tablespaces_dir" . }}/${tablespace}/data"
+      psql -d "$URL" --set tablespace="${tablespace}" --set directory="${tablespacedir}" --set ON_ERROR_STOP=1 <<__SQL__
+        SET synchronous_commit to 'off';
+        CREATE TABLESPACE :"tablespace" LOCATION :'directory';
+    __SQL__
+    done
+
     if [ "${PGBACKREST_BACKUP_ENABLED}" == "1" ]; then
       log "Waiting for pgBackRest API to become responsive"
       while sleep 1; do

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -117,15 +117,25 @@ spec:
       - name: timescaledb
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # When reusing an already existing volume it sometimes happens that the permissions
+        # of the PGDATA and/or wal directory are incorrect. To guard against this, we always correctly
+        # set the permissons of these directories before we hand over to Patroni.
+        # We also create all the tablespaces that are defined, to ensure a smooth restore/recovery on a
+        # pristine set of Volumes.
+        # As PostgreSQL requires to have full control over the permissions of the tablespace directories,
+        # we create a subdirectory "data" in every tablespace mountpoint. The full path of every tablespace
+        # therefore always ends on "/data".
         command:
           - sh
           - "-c"
-          # When reusing an already existing volume it sometimes happens that the permissions
-          # of the PGDATA and/or wal directory are incorrect. To guard against this, we always correctly
-          # set the permissons of these directories before we hand over to Patroni
           - |
             {{ .Values.debug.execStartPre }}
             install -o postgres -g postgres -d -m 0700 {{ include "data_directory" . | quote }} {{ include "wal_directory" . | quote }} || exit 1
+            TABLESPACES={{ $.Values.persistentVolumes.tablespaces | default dict | keys | join " " | quote }}
+            for tablespace in {{ $.Values.persistentVolumes.tablespaces | default dict | keys | join " " }}; do
+              install -o postgres -g postgres -d -m 0700 "{{ include "tablespaces_dir" . }}/${tablespace}/data"
+            done
+
             exec patroni /etc/timescaledb/patroni.yaml
         env:
         # We use mixed case environment variables for Patroni User management,
@@ -220,6 +230,10 @@ spec:
           mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
           subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
         {{- end }}
+{{- range $tablespaceName := keys .Values.persistentVolumes.tablespaces }}
+        - name: {{ $tablespaceName }}
+          mountPath: {{ printf "%s/%s" (include "tablespaces_dir" $) $tablespaceName }}
+{{- end }}
         - mountPath: /etc/timescaledb/patroni.yaml
           subPath: patroni.yaml
           name: patroni-config
@@ -265,6 +279,10 @@ spec:
           mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
           subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
         {{- end }}
+{{- range $tablespaceName := keys .Values.persistentVolumes.tablespaces }}
+        - name: {{ $tablespaceName }}
+          mountPath: {{ printf "%s/%s" (include "tablespaces_dir" $) $tablespaceName }}
+{{- end }}
         - mountPath: /etc/pgbackrest
           name: pgbackrest
           readOnly: true
@@ -392,7 +410,7 @@ spec:
         name: wal-volume
         annotations:
         {{- if .Values.persistentVolumes.wal.annotations }}
-{{ toYaml .Values.persistentVolumes.wal.annotations | indent 8 }}
+{{ toYaml .Values.persistentVolumes.wal.annotations | indent 10 }}
         {{- end }}
         labels:
           app: {{ template "timescaledb.fullname" . }}
@@ -414,3 +432,23 @@ spec:
       {{- end }}
       {{- end }}
   {{- end }}
+{{- range $tablespaceName, $volume := ($.Values.persistentVolumes.tablespaces | default dict ) }}
+    - metadata:
+        name: {{ $tablespaceName }}
+        annotations:
+{{ $volume.annotations | default dict | toYaml | indent 10 }}
+        labels:
+          app: {{ template "timescaledb.fullname" $ }}
+          release: {{ $.Release.Name }}
+          heritage: {{ $.Release.Service }}
+          cluster-name: {{ template "clusterName" $ }}
+          tablespace: {{ $tablespaceName }}
+          purpose: tablespace
+      spec:
+        accessModes:
+{{ $volume.accessModes | default (list "ReadWriteOnce") | toYaml | indent 8 }}
+        resources:
+          requests:
+            storage: "{{ $volume.size }}"
+        storageClassName: {{ $volume.storageClass | default "" }}
+{{- end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -255,12 +255,22 @@ persistentVolumes:
     enabled: True
     size: 1Gi
     subPath: ""
+    storageClass:
     # When changing this mountPath ensure you also change the following key to reflect this:
     # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
     annotations: {}
     accessModes:
       - ReadWriteOnce
+  # Any tablespace mentioned here requires a volume that will be associated with it.
+  # tablespaces:
+    # example1:
+    #   size: 5Gi
+    #   storageClass: gp2
+    # example2:
+    #   size: 5Gi
+    #   storageClass: gp2
+
 
 resources: {}
   # If you do want to specify resources, uncomment the following

--- a/charts/timescaledb-single/values/multiple-tablespaces.yaml
+++ b/charts/timescaledb-single/values/multiple-tablespaces.yaml
@@ -1,0 +1,34 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+# These settings will override the defaults for the Volumes used by your deployment.
+# It will create three Volumes:
+# 1.  500 Gi - Used for the main PostgreSQL Data Files
+# 2.  300 Gi - Used for the PostgreSQL WAL files
+# 3. 5000 Gi - Used for the "historical" tablespace
+#
+#
+# An example[1] on how to create a slow storage class using io1 instead of gp2 EBS storage[2]
+#
+#         apiVersion: storage.k8s.io/v1
+#         kind: StorageClass
+#         metadata:
+#           name: slow
+#         provisioner: kubernetes.io/aws-ebs
+#         parameters:
+#           type: io1
+#           iopsPerGB: "10"
+#
+# 1: https://kubernetes.io/docs/concepts/storage/storage-classes/#aws-ebs
+# 2: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html
+persistentVolumes:
+  data:
+    size: 500Gi
+    storageClass: gp2
+  wal:
+    size: 300Gi
+    storageClass: gp2
+  tablespaces:
+    historical:
+      size: 5Ti
+      storageClass: slow


### PR DESCRIPTION
    Add tablespace support during initialization
    
    Larger deployments, or deployments that want to differentiate in Storage
    type for their data (for example: cost reduction, performance increase)
    *within* a single PostgreSQL instance will need to use multiple Volumes.
    
    The only way to make this work is to use tablespaces in PostgreSQL.
    
    This commit will - if defined - create tablespaces which point to a
    Volume. This relation can only be made (currently, Kubernetes 1.16)
    during the creation of the StatefulSet that serves all the PostgreSQL
    instances.
    
    The backup/restore sequence has been verified to work with the default
    settings and backup enabled.

