### PR TITLE
Reduce the dedicated max wal size from 80% to 60%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 ### Changed
+ * Set autotune max\_wal\_size to 60% (instead of 80%) for a dedicated WAL volume
 ### Removed
 ### Fixed
 

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -90,14 +90,14 @@ spec:
               timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" \
                 {{ range $key, $value := .Values.timescaledbTune.args | default dict }}{{ printf "--%s %s " $key (quote $value)}}{{ end }} -yes
 
-              # If there is a dedicated WAL Volume, we want to set max_wal_size to 80% of that volume
+              # If there is a dedicated WAL Volume, we want to set max_wal_size to 60% of that volume
               # If there isn't a dedicated WAL Volume, we set it to 20% of the data volume
               if [ "${RESOURCES_WAL_VOLUME}" = "0" ]; then
                 WALMAX="${RESOURCES_DATA_VOLUME}"
                 WALPERCENT=20
               else
                 WALMAX="${RESOURCES_WAL_VOLUME}"
-                WALPERCENT=80
+                WALPERCENT=60
               fi
 
               WALMAX=$(numfmt --from=auto ${WALMAX})


### PR DESCRIPTION
This allows more time between the WAL Volume exceeding the set
`max_wal_size` and the disk filling up, which in turn gives more time
for monitoring and alerting to notify an operator who in turn can
prevent an outage.