### PR TITLE
Do not label Job Pods with cluster-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Set autotune max\_wal\_size to 60% (instead of 80%) for a dedicated WAL volume
 ### Removed
 ### Fixed
+ * Prevent creation of replication slots for Jobs
 
 ## [v0.5.2] -  2020-01-31
 

--- a/charts/timescaledb-single/templates/job-update-patroni.yaml
+++ b/charts/timescaledb-single/templates/job-update-patroni.yaml
@@ -35,7 +35,6 @@ spec:
         chart: {{ template "timescaledb.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-        cluster-name: {{ template "clusterName" . }}
     spec:
       restartPolicy: OnFailure
       containers:

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -57,7 +57,6 @@ spec:
             release: {{ $.Release.Name }}
             heritage: {{ $.Release.Service }}
             backup-type: {{ .type }}
-            cluster-name: {{ template "clusterName" $ }}
         spec:
           restartPolicy: OnFailure
           containers:


### PR DESCRIPTION
The cluster-name label is used by Patroni to identify which Pods are
part of the replication topology.

Up to this commit, we labelled every component with the `cluster-name`
label for ease of selection, however, this has a major downside in that
when a Pod is not running Patroni, but it does have the same labels as
set in the PATRONI_KUBERNETES_LABELS environment variables, it is
considered to be part of the replication topology by Patroni.

Patroni *will* therefore create a replication slot for that pod
- which will never be removed as it is not a member of the topology.

Stale replication slots cause WAL pile up and at some point will cause
the WAL volume to fill up, which may cause the PostgreSQL instance to
become unavailable.

As this issue is only happening for pods, I decided to only remove the
labels for the Job Pods, not for the CronJobs or Jobs themselves.

This addresses issue #106

1: https://github.com/zalando/patroni/blob/dc1966e3bcba9fde7f6113e72fdd97395aab6e32/patroni/dcs/kubernetes.py#L201