### PR TITLE
Allow initialization of the cluster from backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  * The possibility to run a [`pgBouncer`](https://www.pgbouncer.org/) container in every Pod.
+ * Allow clusters to be initialized from a backup
 ### Changed
  * Use the PostgreSQL 12 Docker Image by default
 ### Removed

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -62,6 +62,10 @@ ${HOME}/.pod_environment
 ${HOME}/.pgbackrest_environment
 {{- end -}}
 
+{{- define "pgbackrest_bootstrap_environment_dir" -}}
+/etc/pgbackrest/bootstrap
+{{- end -}}
+
 {{- define "data_directory" -}}
 {{ printf "%s/data" .Values.persistentVolumes.data.mountPath }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
@@ -1,7 +1,6 @@
 # This file and its contents are licensed under the Apache License 2.0.
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
 
-{{- if or .Values.backup.enable .Values.backup.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -41,4 +40,3 @@ data:
     {{ $key }}={{ index $get $key }}
 {{- end }}
 ...
-{{ end }}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -96,24 +96,105 @@ data:
     source "{{ template "pod_environment_file" }}"
 
     function log {
-      echo "$(date '+%Y-%m-%d %H:%M:%S') - restore_or_initdb - $1"
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - restore_or_initdb - $1"
     }
 
     PGDATA={{ include "data_directory" . | quote }}
     WALDIR={{ include "wal_directory" . | quote }}
+    # A missing PGDATA points to Patroni removing a botched PGDATA, or manual
+    # intervention. In this scenario, we need to recreate the DATA and WALDIRs
+    # to keep pgBackRest happy
+    [ -d "${PGDATA}" ] || install -o postgres -g postgres -d -m 0700 "${PGDATA}"
+    [ -d "${WALDIR}" ] || install -o postgres -g postgres -d -m 0700 "${WALDIR}"
 
-    # Patroni attaches --scope and --datadir to the arguments, we need to strip them off as
-    # initdb has no business with these parameters
-    initdb_args=""
-    for value in "$@"
-    do
-      [[ $value == --scope* ]] || [[ $value == --datadir* ]] || initdb_args="${initdb_args} $value"
-    done
+    if [ "${BOOTSTRAP_FROM_BACKUP}" == "1" ]; then
+        log "Attempting restore from backup"
+        # we want to override the environment with the environment
+        export $(env -i envdir {{ template "pgbackrest_bootstrap_environment_dir" . | quote }} env) > /dev/null
+        export PGBACKREST_REPO1_PATH={{ index .Values.bootstrapFromBackup "repo1-path" | quote }}
 
-    log "Invoking initdb"
-    initdb --auth-local=peer --auth-host=md5 --pgdata="${PGDATA}" --waldir="${WALDIR}" ${initdb_args}
+        if [ "${PGBACKREST_REPO1_PATH}" == "" ]; then
+            log "Unconfigured repository path"
+            cat << "__EOT__"
+
+    TimescaleDB Single Helm Chart error:
+
+    You should configure the bootstrapFromBackup in your Helm Chart section by explicitly setting
+    the repo1-path to point to the backups.
+
+    For example, if you want to do a disaster recovery, and you want to reuse
+    the backup, you could configure the path as follows:
+
+    ```yaml
+    bootstrapFromBackup:
+      enabled: true
+      repo1-path: {{ (printf "/%s/%s/" .Release.Namespace (include "clusterName" . )) | quote }}
+    ```
+
+    For more information, consult the admin guide:
+    https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/admin-guide.md#bootstrap-from-backup
+
+
+    __EOT__
+
+            exit 1
+        fi
+
+        log "Listing available backup information"
+        pgbackrest info
+        EXITCODE=$?
+        if [ "${EXITCODE}" != "0" ]; then
+            exit $EXITCODE
+        fi
+
+        pgbackrest --log-level-console=detail restore
+        EXITCODE=$?
+        if [ "${EXITCODE}" == "0" ]; then
+            log "pgBackRest restore finished succesfully, starting instance in recovery"
+            # We want to ensure we do not overwrite a current backup repository with archives, therefore
+            # we block archiving from succeeding until Patroni can takeover
+            touch "${PGDATA}/recovery.signal"
+            pg_ctl -D "${PGDATA}" start -o '--archive-command=/bin/false'
+
+            while ! pg_isready -q; do
+                log "Waiting for PostgreSQL to become available"
+                sleep 3
+            done
+
+            # It is not trivial to figure out to what point we should restore, pgBackRest
+            # should be fetching WAL segments until the WAL is exhausted. We'll ask pgBackRest
+            # what the Maximum Wal is that it currently has; as soon as we see that, we can consider
+            # the restore to be done
+            while true; do
+              MAX_BACKUP_WAL="$(pgbackrest info --output=json | python3 -c "import json,sys;obj=json.load(sys.stdin); print(obj[0]['archive'][0]['max']);")"
+              log "Testing whether WAL file ${MAX_BACKUP_WAL} has been restored ..."
+              [ $(find "${PGDATA}/pg_wal/${MAX_BACKUP_WAL}" -type f) ] && break;
+              sleep 30;
+            done
+
+            # At this point we know the final WAL archive has been restored, we should be done.
+            log "The WAL file ${MAX_BACKUP_WAL} has been successully restored, shutting down instance"
+            pg_ctl -D "${PGDATA}" promote
+            pg_ctl -D "${PGDATA}" stop -m fast
+            log "Handing over control to Patroni ..."
+        else
+            log "Bootstrap from backup failed"
+            exit 1
+        fi
+    else
+        # Patroni attaches --scope and --datadir to the arguments, we need to strip them off as
+        # initdb has no business with these parameters
+        initdb_args=""
+        for value in "$@"
+        do
+            [[ $value == --scope* ]] || [[ $value == --datadir* ]] || initdb_args="${initdb_args} $value"
+        done
+
+        log "Invoking initdb"
+        initdb --auth-local=peer --auth-host=md5 --pgdata="${PGDATA}" --waldir="${WALDIR}" ${initdb_args}
+    fi
+
     echo "include_if_exists = '{{ template "tstune_config". }}'" >> "${PGDATA}/postgresql.conf"
-
   post_init.sh: |
     #!/bin/bash
     source "{{ template "pod_environment_file" }}"

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -230,6 +230,8 @@ spec:
           value: "$(PATRONI_POSTGRESQL_DATA_DIR)"
         - name: PGHOST
           value: "{{ template "socket_directory" . }}"
+        - name: BOOTSTRAP_FROM_BACKUP
+          value: {{ .Values.bootstrapFromBackup.enabled | int | quote }}
         {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 8 }}{{- end }}
           # pgBackRest is also called using the archive_command if the backup is enabled.
           # this script will also need access to the environment variables specified for
@@ -301,11 +303,12 @@ spec:
           mountPath: {{ template "callbacks_dir" . }}
           readOnly: true
         {{- end }}
-{{- if or .Values.backup.enabled .Values.backup.enable }}
         - mountPath: /etc/pgbackrest
           name: pgbackrest
           readOnly: true
-{{ end }}
+        - mountPath: {{ template "pgbackrest_bootstrap_environment_dir" . }}
+          name: pgbackrest-bootstrap
+          readOnly: true
         resources:
 {{ toYaml .Values.resources | indent 10 }}
 
@@ -472,6 +475,10 @@ spec:
         secret:
           secretName:  {{ template "secrets_certificate" . }}
           defaultMode: 416 # 0640 permissions
+      - name: pgbackrest-bootstrap
+        secret:
+          secretName: {{ .Values.bootstrapFromBackup.secretName }}
+          optional: True
       {{- if not .Values.persistentVolumes.data.enabled }}
       - name: storage-volume
         emptyDir: {}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -87,6 +87,23 @@ backup:
     #      name: pgbackrest-dev-secrets
     #      key: repo1-s3-key-secret
 
+# When creating a *new* deployment, the default is to initialize (using initdb) the database.
+# If however, you want to initialize the database using an existing backup, you can do so by
+# configuring this section.
+#
+# WARNING: You *should not* run 2 identically named deployments in separate Kubernetes
+#          clusters using the same S3 bucket for backups.
+bootstrapFromBackup:
+  enabled: False
+  # Setting the s3 path is mandatory to avoid overwriting an already existing backup,
+  # and to be sure the restore is explicitly the one requested.
+  repo1-path:
+  # Here you can (optionally) provide a Secret to configure the restore process further.
+  # For example, if you need to specify a different restore bucket, you should set
+  # PGBACKREST_REPO1_S3_BUCKET: <base64 encoded value of the bucket> in these secrets
+  secretName: pgbackrest-bootstrap
+
+
 # Extra custom environment variables.
 # These should be an EnvVar, as this allows you to inject secrets into the environment
 # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core


### PR DESCRIPTION
Currently, replica's will already use the S3 backups if they are
available to create a $PGDATA directory.
However, if no master (endpoint) is available, the behaviour up to now
was to always do an initdb.

This may not be what the user wants, say - a user wants to suspend a
service - removing all the Kubernetes objects and only keeping the S3
backups.

In such a scenario, it would be great if the backup would be used to
initialize the whole cluster.