### PR TITLE
Feike/backup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ * Example for a High Throuhput cluster
+ * Ability to override archive-push/archive-get pgBackRest settings
 ### Changed
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
- * Example for a High Throuhput cluster
+ * Examples for setting up a High Throughput Cluster, or using different backup parameters
  * Ability to override archive-push/archive-get pgBackRest settings
 ### Changed
 ### Removed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -29,7 +29,9 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `tls.cert`                        | The public key of the SSL certificate for PostgreSQL | empty (a self-signed certificate will be generated) |
 | `tls.key`                         | The private key of the SSL Certificate for PostgreSQL | empty                                     |
 | `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
-| `backup.pgBackRest`               | [pgBackRest configuration](https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/values.yaml)     | Working defaults |
+| `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults |
+| `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
+| `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
 | `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core)          | `[]`                                                |

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -185,22 +185,16 @@ This allows you to decouple the secret management of the backup credentials from
 The [pgBackRest Command Reference](https://pgbackrest.org/command.html#introduction) has detailed information about which
 environment variables can be set.
 
-For example, if you would use [Vault](https://www.vaultproject.io/), you could do the following:
+For example, if you create a secret `pgbackrest-secrets`, you could use the following to avoid specifying plain text secrets in the `values.yaml`:
 
 ```yaml
-# Filename: myvalues.yaml
-
 backup:
-  enabled: True
-    pgBackRest:
-      repo1-s3-bucket: this_bucket_may_not_exist
-  env:
-    - name: PGBACKREST_REPO1_S3_KEY
-      value: vault:secret/data/my-system/mydb#PGBACKREST_REPO1_S3_KEY
-    - name: PGBACKREST_REPO1_S3_KEY_SECRET
-      value: vault:secret/data/my-system/mydb#PGBACKREST_REPO1_S3_KEY_SECRET
+  enabled: true
+  envFrom:
+    - secretRef:
+        name: pgbackrest-secrets
 ```
-
+For a full example, have a look at [backup_variations.yaml](values/backup_variations.yaml)
 
 ### Control the backup schedule
 If you want to alter the backup jobs, or their schedule, you can override the `backup.jobs` in your configuration, for example:

--- a/charts/timescaledb-single/templates/sec-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/sec-pgbackrest.yaml
@@ -14,11 +14,14 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
+{{- $globalDefaults := dict "spool-path" (include "socket_directory" .) "compress-level" "3" "repo1-path" (printf "/%s/%s/" .Release.Namespace (include "clusterName" .)) }}
+{{- $globals := merge .Values.backup.pgBackRest $globalDefaults }}
+{{- $push := index .Values.backup "pgBackRest:archive-push" | default dict }}
+{{- $get := index .Values.backup "pgBackRest:archive-get" | default dict }}
   pgbackrest.conf: |
     [global]
-    repo1-path=/{{ .Release.Namespace }}/{{ template "clusterName" . }}/
-{{- range $key, $val := .Values.backup.pgBackRest }}
-    {{ $key }}={{ $val }}
+{{- range $key := keys $globals | sortAlpha }}
+    {{ $key }}={{ index $globals $key }}
 {{- end }}
 
     [poddb]
@@ -34,6 +37,13 @@ stringData:
     link-all=y
 
     [global:archive-push]
-    compress-level=3
+{{- range $key := keys $push | sortAlpha }}
+    {{ $key }}={{ index $push $key }}
+{{- end }}
+
+    [global:archive-get]
+{{- range $key := keys $get | sortAlpha }}
+    {{ $key }}={{ index $get $key }}
+{{- end }}
 ...
 {{ end }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -201,8 +201,8 @@ spec:
           # the backup. This can be removed once we do not directly invoke pgBackRest
           # from inside the TimescaleDB container anymore
         {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 8 }}{{- end }}
-        {{- if .Values.envFrom }}
-        envFrom: {{ .Values.envFrom | default list | toYaml | nindent 8 }}
+        {{- if or .Values.envFrom .Values.backup.envFrom }}
+        envFrom: {{ .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 8 }}
         {{- end }}
         ports:
         - containerPort: 8008

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -46,7 +46,6 @@ backup:
     # https://pgbackrest.org/configuration.html
     process-max: 4
     start-fast: "y"
-    compress-level: 3
     repo1-retention-diff: 2
     repo1-retention-full: 2
     repo1-s3-region: us-east-2
@@ -60,6 +59,10 @@ backup:
     # secrets or other secret injection mechanisms
     repo1-s3-key: examplekeyid
     repo1-s3-key-secret: examplesecret+D48GXfDdtl823nlSRRv7dmB
+  # Overriding the archive-push/archive-get sections is most useful in
+  # very high througput situations. Look at values/high_throuhgput_example.yaml for more details
+  pgBackRest:archive-push: {}
+  pgBackRest:archive-get: {}
   jobs:
       # name: needs to adhere to the kubernetes restrictions
       # type: can be full, incr or diff, see https://pgbackrest.org/user-guide.html

--- a/charts/timescaledb-single/values/backup_variations.yaml
+++ b/charts/timescaledb-single/values/backup_variations.yaml
@@ -1,0 +1,21 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+backup:
+  enabled: true
+  pgBackRest:
+    # The path of the backup defaults to NAMESPACE/DEPLOYMENT, however you may want
+    # to override that here:
+    repo1-path: /testing123/testing456/
+
+  # The referenced secret can be created using kubectl, for example:
+  #
+  # kubectl create secret generic pgbackrest-secrets \
+  # --from-literal=PGBACKREST_REPO1_S3_KEY=examplekeyid \
+  # --from-literal=PGBACKREST_REPO1_S3_KEY_SECRET=examplesecret+D48GXfDdtl823nlSRRv7dmB \
+  # --from-literal=PGBACKREST_REPO1_S3_BUCKET=my_example_s3_bucket_for_backups
+  #
+  # https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-secret
+  envFrom:
+    - secretRef:
+        name: pgbackrest-secrets

--- a/charts/timescaledb-single/values/high_throughput.example.yaml
+++ b/charts/timescaledb-single/values/high_throughput.example.yaml
@@ -1,0 +1,97 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+# High Throughput requires a good throughput on the I/O layer, for most cloud providers,
+# IOPS are related to disk size, therefore setting up a decent sized WAL volume is benificial
+# for getting good troughput.
+#
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html
+# https://cloud.google.com/compute/docs/disks/performance
+#
+persistentVolumes:
+  data:
+    size: 2Ti
+  wal:
+    # We need good IOPS (see above), but we also need a significant amount of disk space
+    # to ensure we have a few hours of previous WAL on disk so replica's or the archiver
+    # can catch up if they have had interruptions.
+    size: 750Gi
+
+patroni:
+  bootstrap:
+    method: restore_or_initdb
+    restore_or_initdb:
+      # Increasing the wal-segsize from the default 16MB to 256MB has the upside of not having
+      # as many files per second, and not as many files in the pg_waldir.
+      # An immediate benefactor is the backup to s3: there will be less API calls, and many
+      # s3 operations with WAL therefore experience a speedup if the default is increased.
+      #
+      # https://www.postgresql.org/docs/current/app-initdb.html (search for --wal-segsize)
+      command: >
+        /etc/timescaledb/scripts/restore_or_initdb.sh
+        --encoding=UTF8
+        --locale=C.UTF-8
+        --wal-segsize=256
+    dcs:
+      # For High Throughput clusters it is likely that the bottleneck will be the recovery
+      # of the WAL on the replica's. If the high throughput is continous, this means
+      # the replica's will never catch up.
+      # Enabling synchronous_mode will ensure that there is at least 1 synchronous replica,
+      # which will ensure that the throughput will be limited to whatever the replica process
+      # of the synchronous replica can process.
+      #
+      # https://patroni.readthedocs.io/en/latest/replication_modes.html#synchronous-mode
+      master_start_timeout: 0
+      synchronous_mode: true
+      postgresql:
+        parameters:
+          # For good performance we want to have a long interval between checkpoints,
+          # however for continous high throughput, the replica's will have very limited
+          # capacity to catch up after a crash/restart.
+          #
+          # For example, if the recovery process of the replica requires on average
+          # 90% of the CPU, it could recover 1.11 seconds of WAL per second.
+          # If after a crash it is delayed by 5 minutes, it will only catch up in:
+          #
+          #   300/(1.11 - 1) = 2727 seconds (roughly 45 minutes)
+          #
+          # We therefore want to pick a middle ground between recoverability of instances
+          # and performance, and for now come up with 5 minutes.
+          checkpoint_timeout: 300s
+          temp_file_limit: '200GB'
+          # remote_apply will throttle the replica's, see also the comment at patroni.bootstrap.synchronous_mode
+          synchronous_commit: remote_apply
+
+# Enabling tuning allows us to use this configuration on many types of instances, therefore we enable it
+timescaledbTune:
+  enabled: true
+
+backup:
+  enabled: true
+
+  # For High Throughput clusters, the archiver will likely not be able to keep up if running synchronously.
+  # Therefore, we'll need to enable asynchronous archiving.
+  #
+  # Not using asynchronous archiving may cause failures far in the future, for example, on a 
+  # cluster with a WAL Volume of 500GB, and an archiver lagging 200MB/minute, the primary pod will only
+  # fail after 2500 minutes, or almost 2 days.
+  pgBackRest:archive-push:
+    process-max: 4
+    archive-async: "y"
+
+  pgBackRest:archive-get:
+    process-max: 4
+    archive-async: "y"
+    archive-get-queue-max: 2GB
+
+  # The referenced secret can be created using kubectl, for example:
+  #
+  # kubectl create secret generic pgbackrest-secrets \
+  # --from-literal=PGBACKREST_REPO1_S3_KEY=examplekeyid \
+  # --from-literal=PGBACKREST_REPO1_S3_KEY_SECRET=examplesecret+D48GXfDdtl823nlSRRv7dmB \
+  # --from-literal=PGBACKREST_REPO1_S3_BUCKET=my_example_s3_bucket_for_backups
+  #
+  # https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-secret
+  envFrom:
+  - secretRef:
+      name: pgbackrest-secrets


### PR DESCRIPTION
# Include example for a High Throughput deployment

The example includes asynchronous archiving, synchronous commit and
large volume sizes. Additionally, as it wasn't that well documented yet,
it gives an example on how to reference an existing secret for the s3
credentials.

I'm not really fond of using ':' in yaml keys, but in this case it seems
the easiest way to map the sections of the pgBackRest configuration file
to yaml keys, without breaking previously built `values.yaml` files.

    pgBackRest              --> global
    pgBackRest:archive-push --> global:archive-push
    pgBackRest:archive-get  --> global:archive-get

These settings were tested on a cluster (3 pods on a dedicated 3 node
m5.xlarge ec2 nodepool) doing > 100K row inserts per second.

To make the example work correctly, some refactoring (backwards
compatible) of `sec-pgbackrest.yaml` was required, which also addresses
issue #109, which was raised to decouple the clusterName from the s3
backup repository path.

# Include example for configuring the backup

This shows a working example to address issue #109