### PR TITLE
Improve speed of failover and recovery

### DIFF
--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -162,4 +162,68 @@ data:
         "${CALLBACK}" $@
       fi
     done
+{{/*
+  # Doing a checkpoint (at the primary and the current instance) before starting
+  # the shutdown process will speed up the CHECKPOINT that is part of the shutdown
+  # process and the recovery after the pod is rescheduled.
+  #
+  # We issue the CHECKPOINT at the primary always because:
+  #
+  # > Restartpoints can't be performed more frequently than checkpoints in the
+  # > master because restartpoints can only be performed at checkpoint records.
+  # https://www.postgresql.org/docs/current/wal-configuration.html
+  #
+  # While we're doing these preStop CHECKPOINTs we can still serve read/write
+  # queries to clients, whereas as soon as we initiate the shutdown, we terminate
+  # connections.
+  #
+  # This therefore reduces downtime for the clients, at the cost of increasing (slightly)
+  # the time to stop the pod, and reducing write performance on the primary.
+  #
+  # To further reduce downtime for clients, we will issue a switchover iff we are currently
+  # running as the primary. This again should be relatively fast, as we've just issued and
+  # waited for the CHECKPOINT to complete.
+  #
+  # This is quite a lot of logic and work in a preStop command; however, if the preStop command
+  # fails for whatever reason, the normal Pod shutdown will commence, so it is only able to
+  # improve stuff without being able to break stuff.
+  # (The $(hostname) inside the switchover call safeguards that we never accidentally
+  # switchover the wrong primary).
+*/}}
+  lifecycle_preStop.psql: |
+    \pset pager off
+    \set ON_ERROR_STOP true
+    \set hostname `hostname`
+    \set dsn_fmt 'user=postgres host=%s application_name=lifecycle:preStop@%s connect_timeout=5 options=''-c log_min_duration_statement=0'''
+
+    SELECT
+        pg_is_in_recovery() AS in_recovery,
+        format(:'dsn_fmt', patroni_scope,                       :'hostname') AS primary_dsn,
+        format(:'dsn_fmt', '{{ template "socket_directory" }}', :'hostname') AS local_dsn
+    FROM
+        current_setting('cluster_name') AS cs(patroni_scope)
+    \gset
+
+    \timing on
+    \set ECHO queries
+
+    -- There should be a CHECKPOINT at the primary
+    \if :in_recovery
+        \connect :"primary_dsn"
+        CHECKPOINT;
+    \endif
+
+    -- There should also be a CHECKPOINT locally,
+    -- for the primary, this may mean we do a double checkpoint,
+    -- but the second one would be cheap anyway, so we leave that as is
+    \connect :"local_dsn"
+    SELECT 'Issuing checkpoint';
+    CHECKPOINT;
+
+    \if :in_recovery
+        SELECT 'We are a replica: Successfully invoked checkpoints at the primary and locally.';
+    \else
+        SELECT 'We are a primary: Successfully invoked checkpoints, now issuing a switchover.';
+        \! curl -s http://localhost:8008/switchover -XPOST -d '{"leader": "$(hostname)"}'
+    \endif
 ...

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -113,10 +113,24 @@ spec:
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
 {{- end }}
+      # Issuing the final checkpoints on a busy database may take considerable time.
+      # Unfinished checkpoints will require more time during startup, so the tradeoff
+      # here is time spent in shutdown/time spent in startup.
+      # We choose shutdown here, especially as during the largest part of the shutdown
+      # we can still serve clients.
+      terminationGracePeriodSeconds: 600
       containers:
       - name: timescaledb
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - psql
+              - -X
+              - --file
+              - "{{ template "scripts_dir" . }}/lifecycle_preStop.psql"
         # When reusing an already existing volume it sometimes happens that the permissions
         # of the PGDATA and/or wal directory are incorrect. To guard against this, we always correctly
         # set the permissons of these directories before we hand over to Patroni.
@@ -125,6 +139,11 @@ spec:
         # As PostgreSQL requires to have full control over the permissions of the tablespace directories,
         # we create a subdirectory "data" in every tablespace mountpoint. The full path of every tablespace
         # therefore always ends on "/data".
+        # By creating a .pgpass file in the $HOME directory, we expose the superuser password
+        # to processes that may not have it in their environment (like the preStop lifecycle hook).
+        # To ensure Patroni will not mingle with this file, we give Patroni its own pgpass file.
+        # As these files are in the $HOME directory, they are only available to *this* container,
+        # and they are ephemeral.
         command:
           - /bin/bash
           - "-c"
@@ -155,6 +174,11 @@ spec:
             do
                 unset "${UNKNOWNVAR}"
             done
+
+            echo "*:*:*:postgres:${PATRONI_SUPERUSER_PASSWORD}" >> ${HOME}/.pgpass
+            chmod 0600 ${HOME}/.pgpass
+
+            export PATRONI_POSTGRESQL_PGPASS="${HOME}/.pgpass.patroni"
 
             exec patroni /etc/timescaledb/patroni.yaml
         env:


### PR DESCRIPTION
By issuing a switchover *before* the pod is terminated, we avoid any
waits that may occur when the Pod is terminated while being a primary.
For relatively idle clusters, this brings the downtime of a primary pod
reschedule to something like 5 - 10 seconds.

For more active clusters, most of the time during shutdown is spent in
the final CHECKPOINT. However, the final CHECKPOINT is issued *after*
clients have already been disconnected, and no connections are allowed
anymore.
Very active clusters may take minutes to complete the CHECKPOINT, which
reduces the availability of the databases. By issuing a CHECKPOINT
*before* the actual shutdown commences, we may still take a significant
amount of time, but we establish 2 things:

1. Clients can still do their work, connect, read/write
2. The CHECKPOINT issued by the shutdown will be faster (if not very
   fast) as the previous CHECKPOINT was only moments ago.

As a restartpoint (CHECKPOINT for replica's) can only be written on the
CHECKPOINT record from the primary, we also issue a CHECKPOINT on the
primary if one of the replica's is terminating.
Recovery of the replica starts at the previous CHECKPOINT record, which
if we do not issue a CHECKPOINT, may be many minutes (say 10) in the
past.

For very active clusters (say 80% CPU usage for the recovery process),
this may mean that the replica will only catch up 1.25 minutes every
minute, or in other words, it requires 40 minutes to recover the 10
minutes from the previous CHECKPOINT.

If the CHECKPOINT issued here however is recent (say the pod restarts in
1 minute) we now only need 4 minutes to catch up with the primary and
resume the duty of a replica.

https://www.postgresql.org/docs/current/wal-configuration.html