### PR TITLE
allow adding extraSpec to service definitions

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -50,11 +50,13 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
+| `loadBalancer.extraSpec`          | Extra configuration for service spec        | `{}`                                                |
 | `networkPolicy.enabled`           | If enabled, creates a NetworkPolicy for controlling network access | `false`
 | `networkPolicy.ingress`           | A list of Ingress rules to extend the base NetworkPolicy | `nil`
 | `networkPolicy.prometheusApp`     | Name of Prometheus app to allow it to scrape exporters | `prometheus`
 | `replicaLoadBalancer.enabled`     | If enabled, creates a LB for replica's only | `false`                                             |
 | `replicaLoadBalancer.annotations` | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
+| `replicaLoadBalancer.extraSpec`   | Extra configuration for replica service spec | `{}`                                                |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
 | `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
 | `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |
@@ -211,7 +213,7 @@ To fully purge a deployment in Kubernetes, you should do the following:
 ```sh
 # Delete the Helm deployment
 helm delete my-release
-# Delete pvc 
+# Delete pvc
 RELEASE=my-release
 kubectl delete $(kubectl get pvc -l release=$RELEASE -o name)
 ```

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -50,13 +50,13 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
-| `loadBalancer.extraSpec`          | Extra configuration for service spec        | `{}`                                                |
+| `loadBalancer.spec`          | Extra configuration for service spec        | `{}`                                                |
 | `networkPolicy.enabled`           | If enabled, creates a NetworkPolicy for controlling network access | `false`
 | `networkPolicy.ingress`           | A list of Ingress rules to extend the base NetworkPolicy | `nil`
 | `networkPolicy.prometheusApp`     | Name of Prometheus app to allow it to scrape exporters | `prometheus`
 | `replicaLoadBalancer.enabled`     | If enabled, creates a LB for replica's only | `false`                                             |
 | `replicaLoadBalancer.annotations` | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
-| `replicaLoadBalancer.extraSpec`   | Extra configuration for replica service spec | `{}`                                                |
+| `replicaLoadBalancer.spec`   | Extra configuration for replica service spec | `{}`                                                |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
 | `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
 | `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |

--- a/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
@@ -29,3 +29,4 @@ spec:
     # This always defaults to 5432, even if `!replicaLoadBalancer.enabled`.
     port: {{ .Values.replicaLoadBalancer.port }}
     protocol: TCP
+{{ .Values.replicaLoadBalancer.extraSpec | toYaml | indent 2 }}

--- a/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
@@ -29,4 +29,4 @@ spec:
     # This always defaults to 5432, even if `!replicaLoadBalancer.enabled`.
     port: {{ .Values.replicaLoadBalancer.port }}
     protocol: TCP
-{{ .Values.replicaLoadBalancer.extraSpec | toYaml | indent 2 }}
+{{ .Values.replicaLoadBalancer.spec | toYaml | indent 2 }}

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -26,3 +26,4 @@ spec:
     port: {{ .Values.loadBalancer.port }}
     targetPort: postgresql
     protocol: TCP
+{{ .Values.replicaLoadBalancer.extraSpec | toYaml | indent 2 }}

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -26,4 +26,4 @@ spec:
     port: {{ .Values.loadBalancer.port }}
     targetPort: postgresql
     protocol: TCP
-{{ .Values.replicaLoadBalancer.extraSpec | toYaml | indent 2 }}
+{{ .Values.loadBalancer.spec | toYaml | indent 2 }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -227,7 +227,7 @@ loadBalancer:
     # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
     # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
   # Define extra things that should go in the service spec
-  extraSpec: {}
+  spec: {}
     # loadBalancerSourceRanges:
     # - "0.0.0.0/0"
 
@@ -239,7 +239,7 @@ replicaLoadBalancer:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
   # Define extra things that should go in the service spec
-  extraSpec: {}
+  spec: {}
     # loadBalancerSourceRanges:
     # - "0.0.0.0/0"
 

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -226,6 +226,10 @@ loadBalancer:
 
     # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
     # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
+  # Define extra things that should go in the service spec
+  extraSpec: {}
+    # loadBalancerSourceRanges:
+    # - "0.0.0.0/0"
 
 replicaLoadBalancer:
   # If not enabled, we still expose the replica's using a so called Headless Service
@@ -234,6 +238,10 @@ replicaLoadBalancer:
   port: 5432
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
+  # Define extra things that should go in the service spec
+  extraSpec: {}
+    # loadBalancerSourceRanges:
+    # - "0.0.0.0/0"
 
 readinessProbe:
   enabled: true


### PR DESCRIPTION
This allows adding arbitrary additional sections to spec for the services - for example, `loadBalancerSourceRanges` for network load balancers.