### PR TITLE
Scrub the Patroni/PostgreSQL environment

### DIFF
--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -54,6 +54,14 @@ Create the name of the service account to use.
 /var/run/postgresql
 {{- end -}}
 
+{{- define "pod_environment_file" -}}
+${HOME}/.pod_environment
+{{- end -}}
+
+{{- define "pgbackrest_environment_file" -}}
+${HOME}/.pgbackrest_environment
+{{- end -}}
+
 {{- define "data_directory" -}}
 {{ printf "%s/data" .Values.persistentVolumes.data.mountPath }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -24,15 +24,16 @@ data:
   pgbackrest_archive.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 0
 
+    source "{{ template "pgbackrest_environment_file" }}"
     exec pgbackrest --stanza=poddb archive-push $1
   pgbackrest_archive_get.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 1
 
+    source "{{ template "pgbackrest_environment_file" }}"
     exec pgbackrest --stanza=poddb archive-get ${1} "${2}"
   pgbackrest_bootstrap.sh: |
     #!/bin/bash
@@ -62,6 +63,8 @@ data:
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
     [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 1
 
+    source "{{ template "pod_environment_file" }}"
+
     PGDATA={{ include "data_directory" . | quote }}
     WALDIR={{ include "wal_directory" . | quote }}
 
@@ -74,6 +77,8 @@ data:
     pgbackrest --stanza=poddb --force --delta --log-level-console=detail restore
   restore_or_initdb.sh: |
     #!/bin/bash
+
+    source "{{ template "pod_environment_file" }}"
 
     function log {
       echo "$(date '+%Y-%m-%d %H:%M:%S') - restore_or_initdb - $1"
@@ -97,6 +102,8 @@ data:
   post_init.sh: |
     #!/bin/bash
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
+
+    source "{{ template "pod_environment_file" }}"
 
     function log {
         echo "$(date '+%Y-%m-%d %H:%M:%S') - post_init - $1"
@@ -144,6 +151,8 @@ data:
   patroni_callback.sh: |
     #!/bin/bash
     set -e
+
+    source "{{ template "pod_environment_file" }}"
 
     for suffix in "$1" all
     do

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -126,7 +126,7 @@ spec:
         # we create a subdirectory "data" in every tablespace mountpoint. The full path of every tablespace
         # therefore always ends on "/data".
         command:
-          - sh
+          - /bin/bash
           - "-c"
           - |
             {{ .Values.debug.execStartPre }}
@@ -134,6 +134,26 @@ spec:
             TABLESPACES={{ $.Values.persistentVolumes.tablespaces | default dict | keys | join " " | quote }}
             for tablespace in {{ $.Values.persistentVolumes.tablespaces | default dict | keys | join " " }}; do
               install -o postgres -g postgres -d -m 0700 "{{ include "tablespaces_dir" . }}/${tablespace}/data"
+            done
+
+            # Environment variables can be read by regular users of PostgreSQL. Especially in a Kubernetes
+            # context it is likely that some secrets are part of those variables.
+            # To ensure we expose as little as possible to the underlying PostgreSQL instance, we have a list
+            # of allowed environment variable patterns to retain.
+            #
+            # We need the KUBERNETES_ environment variables for the native Kubernetes support of Patroni to work.
+            #
+            # NB: Patroni will remove all PATRONI_.* environment variables before starting PostgreSQL
+
+            # We store the current environment, as initscripts, callbacks, archive_commands etc. may require
+            # to have the environment available to them
+            set -o posix
+            export -p > "{{ template "pod_environment_file" }}"
+            export -p | grep PGBACKREST > "{{ template "pgbackrest_environment_file" }}"
+
+            for UNKNOWNVAR in $(env | awk -F '=' '!/^(PATRONI_.*|HOME|PGDATA|PGHOST|LC_.*|LANG|PATH|KUBERNETES_SERVICE_.*)=/ {print $1}')
+            do
+                unset "${UNKNOWNVAR}"
             done
 
             exec patroni /etc/timescaledb/patroni.yaml


### PR DESCRIPTION
Environment variables that are present at postmaster start may leak to
regular user sessions.
We therefore want to only pass along those environment variables that
are necessary for Patroni/PostgreSQL to function.

Patroni itself is aware of this, and therefore will already scrub all
the environment variables starting with PATRONI_ from the environment
before starting PostgreSQL, however, other environment variables may be
set that carry secrets, as that is quite a common setup in a Kubernetes
deployment.

To ensure the environment *is* available to callbacks, archive scripts,
backup scripts etc we store the environment before invoking Patroni and
we source the environment if any of these scripts are executed.

The immediate use case that is covered here is the exposing of S3 access
keys/secrets that are injected using `envFrom` or `env` settings in the
Values files, which in turn are referencing Kubernetes secrets.