### PR TITLE
Add securityContext configuration

### DIFF
--- a/charts/timescaledb-single/templates/job-update-patroni.yaml
+++ b/charts/timescaledb-single/templates/job-update-patroni.yaml
@@ -40,6 +40,8 @@ spec:
       containers:
       - name: {{ template "timescaledb.fullname" . }}-patch-patroni-config
         image: curlimages/curl
+        securityContext:
+          runAsUser: 100
         command: ["/usr/bin/curl"]
         args:
         - --connect-timeout

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -62,6 +62,8 @@ spec:
           containers:
             - name: {{ template "timescaledb.fullname" $ }}-{{ .type }}
               image: curlimages/curl
+              securityContext:
+                runAsUser: 100
               command: ["/usr/bin/curl"]
               args:
               - --connect-timeout

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -41,6 +41,10 @@ spec:
 {{- if .Values.timescaledbTune.enabled }}
       - name: tstune
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
         env:
         - name: TSTUNE_FILE
           value: {{ template "tstune_config" . }}
@@ -116,6 +120,10 @@ spec:
       containers:
       - name: timescaledb
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # When reusing an already existing volume it sometimes happens that the permissions
         # of the PGDATA and/or wal directory are incorrect. To guard against this, we always correctly
@@ -281,6 +289,10 @@ spec:
 {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - {{ template "scripts_dir" . }}/pgbackrest_bootstrap.sh

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -19,6 +19,9 @@ image:
   tag: pg11-ts1.6
   pullPolicy: IfNotPresent
 
+securityContext:
+  runAsUser: 1000
+
 # Credentials used by PostgreSQL and Patroni
 # https://github.com/zalando/patroni/blob/master/docs/SETTINGS.rst#postgresql
 credentials:


### PR DESCRIPTION
This PR adds securityContext to containers with static images (can not be changed via values.yaml) and customizable securityContext to values.yaml for the image, that can be set in values.yaml

Related to #124 