### PR TITLE
Use fullname for anti-affinity clause (bugfix)

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -383,7 +383,7 @@ affinityTemplate: |
         topologyKey: "kubernetes.io/hostname"
         labelSelector:
           matchLabels:
-            app:  {{ template "timescaledb.name" . }}
+            app: {{ template "timescaledb.fullname" . }}
             release: {{ .Release.Name | quote }}
             cluster-name: {{ template "clusterName" . }}
     - weight: 50
@@ -391,7 +391,7 @@ affinityTemplate: |
         topologyKey: failure-domain.beta.kubernetes.io/zone
         labelSelector:
           matchLabels:
-            app:  {{ template "timescaledb.name" . }}
+            app: {{ template "timescaledb.fullname" . }}
             release: {{ .Release.Name | quote }}
             cluster-name: {{ template "clusterName" . }}
 affinity: {}


### PR DESCRIPTION
While benchmarking I ran into the situation that pods were not scheduled
evenly across all nodes of set of nodes.

The cause was that the labelSelector was using the wrong value in the
app label to match pods.