### PR TITLE
Allow mounting /dev/shm from Memory

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -249,6 +249,10 @@ spec:
           mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
           subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
         {{- end }}
+        {{- if .Values.sharedMemory.useMount }}
+        - name: shared-memory
+          mountPath: /dev/shm
+        {{- end }}
 {{- range $tablespaceName := ( .Values.persistentVolumes.tablespaces | default dict | keys ) }}
         - name: {{ $tablespaceName }}
           mountPath: {{ printf "%s/%s" (include "tablespaces_dir" $) $tablespaceName }}
@@ -380,12 +384,17 @@ spec:
           name: {{ .Values.callbacks.configMap }}
           defaultMode: 488 # 0750 permissions
       {{- end }}
-{{- if or .Values.backup.enabled .Values.backup.enable }}
+      {{- if .Values.sharedMemory.useMount }}
+      - name: shared-memory
+        emptyDir:
+          medium: Memory
+      {{- end }}
+      {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         secret:
           secretName: {{ template "timescaledb.fullname" . }}-pgbackrest
           defaultMode: 416 # 0640 permissions
-{{ end }}
+      {{- end }}
       - name: certificate
         secret:
           secretName: {{ template "timescaledb.fullname" . }}-certificate

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -297,6 +297,21 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+sharedMemory:
+  # By default Kubernetes only provides 64MB to /dev/shm
+  # /dev/shm is only used by PostgreSQL for work_mem for parallel workers,
+  # so most will not run into this issue.
+  # https://github.com/kubernetes/kubernetes/issues/28272
+  #
+  # If you do however run into:
+  #
+  #   SQLSTATE 53100
+  #   ERROR:  could not resize shared memory segment "/PostgreSQL.12345" to 4194304 bytes:
+  #   No space left on device
+  #
+  # you may wish to use a mount to Memory, by setting useMount to true
+  useMount: false
+
 # timescaledb-tune will be run with the Pod resources requests or - if not set - its limits.
 # This should give a reasonably tuned PostgreSQL instance.
 # Any PostgreSQL parameter that is explicitly set in the Patroni configuration will override


### PR DESCRIPTION
The default size for /dev/shm in Kubernetes is 64MB, this however is not
sufficient for every deployment.

Addresses issue #127

For some background:
- Support Posix Shared Memory across containers in a pod
  https://github.com/kubernetes/kubernetes/issues/28272
- Increase POSIX Shared Memory for Kubernetes
  https://docs.okd.io/latest/dev_guide/shared_memory.html