### PR TITLE
Add (replica)loadBalancer.port config.

### DIFF
--- a/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
@@ -26,5 +26,6 @@ spec:
 {{- end }}
   ports:
   - name: postgresql
-    port: 5432
+    # This always defaults to 5432, even if `!replicaLoadBalancer.enabled`.
+    port: {{ .Values.replicaLoadBalancer.port }}
     protocol: TCP

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -22,6 +22,7 @@ spec:
 {{- end }}
   ports:
   - name: postgresql
-    port: 5432
+    # This always defaults to 5432, even if `!loadBalancer.enabled`.
+    port: {{ .Values.loadBalancer.port }}
     targetPort: postgresql
     protocol: TCP

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -217,6 +217,7 @@ loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service
   # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
   enabled: True
+  port: 5432
   # Read more about the AWS annotations here:
   # https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws
   # https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html
@@ -232,6 +233,7 @@ replicaLoadBalancer:
   # If not enabled, we still expose the replica's using a so called Headless Service
   # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
   enabled: False
+  port: 5432
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
 


### PR DESCRIPTION
This provides control over the port which is to be exposed by the load
balancer, allowing multiple logical clusters to be exposed over
different load balancers without running into port conflicts.