### PR TITLE
Update the callbacks.configMap value to be templated

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
 | `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core)          | `[]`                                                |
 | `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
-| `callbacks.configMapTpl`          | Templated name of a kubernetes ConfigMap containing [Patroni callbacks](#callbacks) | `nil`                         |
+| `callbacks.configMap`          | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
 | `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
 | `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
 | `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -37,7 +37,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
 | `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core)          | `[]`                                                |
 | `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
-| `callbacks.configMap`             | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks) | `nil`                         |
+| `callbacks.configMapTpl`          | Templated name of a kubernetes ConfigMap containing [Patroni callbacks](#callbacks) | `nil`                         |
 | `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
 | `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
 | `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
@@ -421,7 +421,9 @@ Patroni will trigger some callbacks on certain events. These are:
 - on_stop
 
 If you wish to have *your* script run after a certain event happens, you can do so by configuring
-`callbacks.configMap` to point to a [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#configmap-v1-core).
+`callbacks.configMapTpl` to point to a [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#configmap-v1-core). The value is templated so you can use `"{{ .Release.Name }}-patroni-callbacks"`
+if you're deploying this chart in the same release with another chart that will create the config map.
+
 This ConfigMap should exist before you install a chart. The data keys that match the event names will be executed
 if the event happens. For convenience the `all` key will be executed at every event.
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -421,7 +421,7 @@ Patroni will trigger some callbacks on certain events. These are:
 - on_stop
 
 If you wish to have *your* script run after a certain event happens, you can do so by configuring
-`callbacks.configMapTpl` to point to a [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#configmap-v1-core). The value is templated so you can use `"{{ .Release.Name }}-patroni-callbacks"`
+`callbacks.configMap` to point to a [ConfigMap](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#configmap-v1-core). The value is templated so you can use `"{{ .Release.Name }}-patroni-callbacks"`
 if you're deploying this chart in the same release with another chart that will create the config map.
 
 This ConfigMap should exist before you install a chart. The data keys that match the event names will be executed

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -293,7 +293,7 @@ spec:
           readOnly: true
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
-        {{ if .Values.callbacks.configMap -}}
+        {{ if .Values.callbacks.configMapTpl -}}
         - name: patroni-callbacks
           mountPath: {{ template "callbacks_dir" . }}
           readOnly: true
@@ -402,10 +402,10 @@ spec:
         configMap:
           name: {{ template "timescaledb.fullname" . }}-scripts
           defaultMode: 488 # 0750 permissions
-      {{ if .Values.callbacks.configMap -}}
+      {{ if .Values.callbacks.configMapTpl -}}
       - name: patroni-callbacks
         configMap:
-          name: {{ .Values.callbacks.configMap }}
+          name: {{ tpl .Values.callbacks.configMapTpl . }}
           defaultMode: 488 # 0750 permissions
       {{- end }}
       {{- if .Values.sharedMemory.useMount }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -293,7 +293,7 @@ spec:
           readOnly: true
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
-        {{ if .Values.callbacks.configMapTpl -}}
+        {{ if .Values.callbacks.configMap -}}
         - name: patroni-callbacks
           mountPath: {{ template "callbacks_dir" . }}
           readOnly: true
@@ -402,10 +402,10 @@ spec:
         configMap:
           name: {{ template "timescaledb.fullname" . }}-scripts
           defaultMode: 488 # 0750 permissions
-      {{ if .Values.callbacks.configMapTpl -}}
+      {{ if .Values.callbacks.configMap -}}
       - name: patroni-callbacks
         configMap:
-          name: {{ tpl .Values.callbacks.configMapTpl . }}
+          name: {{ tpl .Values.callbacks.configMap . }}
           defaultMode: 488 # 0750 permissions
       {{- end }}
       {{- if .Values.sharedMemory.useMount }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -211,7 +211,7 @@ patroni:
 
 callbacks:
   # If set, this configMap will be used for the Patroni callbacks.
-  configMapTpl: # example-patroni-callbacks
+  configMap: # example-patroni-callbacks
 
 loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -211,7 +211,7 @@ patroni:
 
 callbacks:
   # If set, this configMap will be used for the Patroni callbacks.
-  configMap: # example-patroni-callbacks
+  configMapTpl: # example-patroni-callbacks
 
 loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service


### PR DESCRIPTION
When combining this chart in a release with other charts
that wish to initialize the database somehow it is easier
to have the callback config map name be templated.