### PR TITLE
Feature/pgbackrest pg12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 ### Fixed
+ * Sequence of events to trigger the first backup/stanza-create
 
 ## [v0.5.7] - 2020-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
- * Support for PostgreSQL 12
- * Default to PostgreSQL 11, TimescaleDB 1.7
 ### Changed
 ### Removed
+### Fixed
+
+## [v0.5.8] - 2020-05-07
+
+### Added
+ * Support for PostgreSQL 12
+ * Default to PostgreSQL 11, TimescaleDB 1.7
 ### Fixed
  * Sequence of events to trigger the first backup/stanza-create
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ * Support for PostgreSQL 12
+ * Default to PostgreSQL 11, TimescaleDB 1.7
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
@@ -29,9 +29,11 @@ data:
     pg1-path={{ template "data_directory" . }}
     pg1-socket-path={{ template "socket_directory" . }}
 
+{{- if lt .Values.version 12.0 }}
     recovery-option=standby_mode=on
     recovery-option=recovery_target_timeline=latest
     recovery-option=recovery_target_action=shutdown
+{{- end }}
 
     link-all=y
 

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -48,11 +48,17 @@ data:
         sleep 3
     done
 
+    # We'll be lazy; we wait for another while to allow the database to promote
+    # to primary if it's the only one running
+    sleep 10
+
     # If we are the primary, we want to create/validate the backup stanza
     if [ "$(psql -c "SELECT pg_is_in_recovery()::text" -AtXq)" == "false" ]; then
         pgbackrest check || {
             log "Creating pgBackrest stanza"
             pgbackrest --stanza=poddb stanza-create --log-level-stderr=info || exit 1
+            log "Creating initial backup"
+            pgbackrest --type=full backup || exit 1
         }
     fi
 
@@ -101,8 +107,6 @@ data:
 
   post_init.sh: |
     #!/bin/bash
-    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-
     source "{{ template "pod_environment_file" }}"
 
     function log {
@@ -131,20 +135,6 @@ data:
         CREATE TABLESPACE :"tablespace" LOCATION :'directory';
     __SQL__
     done
-
-    if [ "${PGBACKREST_BACKUP_ENABLED}" == "1" ]; then
-      log "Waiting for pgBackRest API to become responsive"
-      while sleep 1; do
-          if [ $SECONDS -gt 10 ]; then
-              log "pgBackRest API did not respond within $SECONDS seconds, will not trigger a backup"
-              exit 0
-          fi
-          timeout 1 bash -c "echo > /dev/tcp/localhost/8081" 2>/dev/null && break
-      done
-
-      log "Triggering pgBackRest backup"
-      curl -i -X POST http://localhost:8081/backups
-    fi
 
     # We always exit 0 this script, otherwise the database initialization fails.
     exit 0

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -12,11 +12,14 @@ nameOverride: timescaledb
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#global-universal
 clusterName:
 
+# The major PostgreSQL version to use
+version: 11
+
 image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescaledev/timescaledb-ha
-  tag: pg11-ts1.6
+  tag: pg11-ts1.7
   pullPolicy: IfNotPresent
 
 # These secrets should exist before the Helm is used to deploy this TimescaleDB.
@@ -48,6 +51,8 @@ backup:
     repo1-retention-full: 2
     repo1-type: s3
     repo1-cipher-type: "none"
+    repo1-s3-region: us-east-2
+    repo1-s3-endpoint: s3.amazonaws.com
 
   # Overriding the archive-push/archive-get sections is most useful in
   # very high througput situations. Look at values/high_throuhgput_example.yaml for more details


### PR DESCRIPTION

# Initiate backup from the backup sidecar

Previously, the backup was only triggered after a database
initialization. As this is a one-time event, if the backup was
(temporarily) broken, or the deployment started out without a backup, no
initial backup would be created.
The first backup of that cluster would then be the first one triggered
by the CronJobs.

Every (restarted) pod that start PostgreSQL will have PostgreSQL running
in recovery. This is by design, and Patroni will promote the instance if
necessary.
This however caused quite a few issues where the backup sidecar did not
initiate a stanza-create as the database was still in this initial in
recovery phase.

A classic race, which is classically solved by sticking a sleep 10 in
there.

# Ensure the backup works, also with PostgreSQL 12

In PostgreSQL 12, recovery.conf is deprecated, therefore we do not need
to set the recovery options in the pgBackRest configuration.
