### PR TITLE
Use Docker Image PostgreSQL version by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Removed
+ * Recovery configuration options for pgBackRest
 ### Fixed
 
 ## [v0.5.8] - 2020-05-07

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -25,8 +25,9 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `clusterName`                     | Override the name of the PostgreSQL cluster | Equal to the Helm release name                      |
 | `fullnameOverride`                | Override the fullname of the chart          | `nil`                                               |
 | `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
+| `version`                         | The major PostgreSQL version to use         | empty, defaults to the Docker image default         |
 | `image.repository`                | The image to pull                           | `timescaledev/timescaledb-ha`                       |
-| `image.tag`                       | The version of the image to pull            | `pg11-ts1.6`                                        |
+| `image.tag`                       | The version of the image to pull            | `pg11-ts1.7`                                        |
 | `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `secretNames.credentials`         | Existing secret that contains env vars that influence Patroni (e.g. PATRONI_SUPERUSER_PASSWORD) | `RELEASE-credentials` | 
 | `secretNames.certificate`         | Existing `type:kubernetes.io/tls` secret containing a tls.key and tls.crt | `RELEASE-certificate` |

--- a/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
@@ -29,12 +29,6 @@ data:
     pg1-path={{ template "data_directory" . }}
     pg1-socket-path={{ template "socket_directory" . }}
 
-{{- if lt .Values.version 12.0 }}
-    recovery-option=standby_mode=on
-    recovery-option=recovery_target_timeline=latest
-    recovery-option=recovery_target_action=shutdown
-{{- end }}
-
     link-all=y
 
     [global:archive-push]

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -228,6 +228,10 @@ spec:
           # the backup. This can be removed once we do not directly invoke pgBackRest
           # from inside the TimescaleDB container anymore
         {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 8 }}{{- end }}
+        {{- if .Values.version }}
+        - name: PATH
+          value: /usr/lib/postgresql/{{ .Values.version }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ template "secrets_credentials" . }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -12,8 +12,9 @@ nameOverride: timescaledb
 # https://patroni.readthedocs.io/en/latest/SETTINGS.html#global-universal
 clusterName:
 
-# The major PostgreSQL version to use
-version: 11
+# The major PostgreSQL version to use, defaults to the default version of the Docker image
+# However, in pg_upgrade scenarios, you may need to specify an explicit version
+version:
 
 image:
   # Image was built from


### PR DESCRIPTION
In the previous tag, the default was set to 11, however this was not
propagated to either the PATH environment variable or the
patroni.postgresql.bin_dir, causing the behaviour to be broken.

Testing shows that the recovery options that were part of the pgBackRest
configuration are not required even for PostgreSQL 11, so we can remove
those lines altogether.

We still do need the option for someone to specify the version
explicitly, this allows someone to switch to a PostgreSQL 12 Docker
Image, while still running PostgreSQL 11, this allows you to decouple
the upgrading of Docker Images from running the pg_upgrade.