### PR TITLE
Create random credentials once if unsafe == true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ * Ability to randomly create credentials, called `unsafe`
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `serviceAccount.create`           | If true, create a new service account       | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |
 | `timescaledbTune.enabled`         | If true, runs `timescaledb-tune` before starting PostgreSQL | `false`                             |
+| `unsafe`                          | If true, will generate random a random certificate and random credentials, removing the need for the pre-installation steps with secrets | `false`. This should only be `true` for throw-away (evaluation) deployments |
 
 ### Creating the Secrets
 

--- a/charts/timescaledb-single/templates/unsafe_credentials.yaml
+++ b/charts/timescaledb-single/templates/unsafe_credentials.yaml
@@ -1,0 +1,51 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+{{- if (.Values.unsafe | default false) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "secrets_credentials" $ }}"
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+    cluster-name: {{ template "clusterName" . }}
+  annotations:
+    "helm.sh/hook": pre-install
+type: Opaque
+data:
+  PATRONI_SUPERUSER_PASSWORD: {{ randAlphaNum 16 | b64enc }}
+  PATRONI_REPLICATION_PASSWORD: {{ randAlphaNum 16 | b64enc }}
+  PATRONI_admin_PASSWORD: {{ randAlphaNum 16 | b64enc }}
+...
+---
+{{ $ca := genCA (include "clusterName" .) 1826 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "secrets_certificate" $ }}
+  labels:
+    app: {{ template "timescaledb.fullname" $ }}
+    cluster-name: {{ template "clusterName" $ }}
+  annotations:
+    "helm.sh/hook": pre-install
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $ca.Cert | b64enc }}
+  tls.key: {{ $ca.Key  | b64enc }}
+...
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ template "secrets_pgbackrest" $ }}"
+  labels:
+    app: {{ template "timescaledb.fullname" $ }}
+    cluster-name: {{ template "clusterName" $ }}
+  annotations:
+    "helm.sh/hook": pre-install
+type: Opaque
+data:
+  PGBACKREST_REPO1_S3_REGION: dXMtZWFzdC0y # us-east-2
+...
+{{- end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -426,6 +426,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# Setting unsafe to true will generate some random credentials. This is meant
+# for development or first evaluation of the Helm Charts. It should *not* be
+# used for anything beyong the evaluation phase.
+unsafe: false
+
 debug:
   # This setting is mainly for during development, debugging or troubleshooting.
   # This command will be executed *before* the main container starts. In the


### PR DESCRIPTION
During development and quick evaluation of the Helm Charts it is useful
to not worry about credentials too much.

Currently, some pre-installation steps are required to install this
Chart successfully. The value of those steps is that it ensures the
Secrets that are used are outside the control (and values) of Helm.
However, this is not as easy as generating some random credentials.

Therefore, introduce the unsafe boolean, it will create some random
credentials and a random certificate before installation.