### PR TITLE
add name for containerPort: 5432

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -245,6 +245,7 @@ spec:
         ports:
         - containerPort: 8008
         - containerPort: 5432
+          name: postgresql
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:


### PR DESCRIPTION
a small fix for named port error with kubectl port-foward

$ kubectl port-forward svc/test-timescaledb-0 5432
error: Pod 'test-timescaledb-0' does not have a named port 'postgresql'

Issue #158 