### PR TITLE
Allow generate_kustomization to run on MacOS

### DIFF
--- a/charts/timescaledb-single/generate_kustomization.sh
+++ b/charts/timescaledb-single/generate_kustomization.sh
@@ -6,6 +6,7 @@
 # The purpose of this script is to create a kustomization specifically for a
 # single deployment. It does this by copying the example kustomization,
 # renaming the relevant bits, and generating (random) credentials and certificates
+export LC_ALL=C
 
 if test "$1" = "";
 then
@@ -17,6 +18,7 @@ Example:
 $0 my-deployment
 $0 my-deployment /secrets/my-deployment/
 __EOT__
+    exit 1
 fi
 DEPLOYMENT="$1"
 shift


### PR DESCRIPTION
In Issue #156 it was reported that the script isn't working on MacOS.
Even though in commit f605da32 some fixes were already included to make
it work, it does not seem to suffice.

Also, actually exit the script if called without arguments.