### PR TITLE
Prevent noisy warnings from being shown

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -175,6 +175,8 @@ spec:
                 unset "${UNKNOWNVAR}"
             done
 
+            touch {{ template "tstune_config" . | quote }}
+
             echo "*:*:*:postgres:${PATRONI_SUPERUSER_PASSWORD}" >> ${HOME}/.pgpass
             chmod 0600 ${HOME}/.pgpass
 


### PR DESCRIPTION
If timescaledb-tune was disabled, the log of the timescaledb container
would be showing a lot of:

LOG:  skipping missing configuration file "/var/run/postgresql/timescaledb.conf"

error messages. These are not harmful in any way, however they do
generate noise, which may confuse anyone looking at them.

By touching the file, we ensure the file is there, even if it's only
empty.