### PR TITLE
Allow most values to be nil in values.yaml

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -34,19 +34,19 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `secretNames.pgbackrest`          | Existing secret that contains env vars that influence pgBackRest (e.g. PGBACKREST_REPO1_S3_KEY_SECRET) | `RELEASE-pgbackgrest` |
 | `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
 | `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults |
-| `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
-| `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
+| `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) |  |
+| `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  |  |
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
 | `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core)          | `[]`                                                |
 | `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
 | `callbacks.configMap`          | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
-| `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
+| `resources`                       | Any resources you wish to assign to the pod |                                                     |
 | `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
-| `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
-| `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
+| `nodeSelector`                    | Node label to use for scheduling            |                                                     |
+| `tolerations`                     | List of node taints to tolerate             |                                                     |
 | `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname and (availability) zone |
-| `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
+| `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. |                                         |
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
 | `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume. If disabled, WAL will be on the Data Volume | `true`     |
 | `persistentVolumes.wal.mountPath` | Persistent Wal Volume mount root path       | `/var/lib/postgresql/wal/`                          |
 | `persistentVolumes.<name>.accessModes` | Persistent Volume access modes         | `[ReadWriteOnce]`                                   |
-| `persistentVolumes.<name>.annotations` | Annotations for Persistent Volume Claim| `{}`                                                |
+| `persistentVolumes.<name>.annotations` | Annotations for Persistent Volume Claim|                                                     |
 | `persistentVolumes.<name>.size`   | Persistent Volume size                      | `2Gi`                                               |
 | `persistentVolumes.<name>.storageClass`| Persistent Volume Storage Class        | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolumes.<name>.subPath`| Subdirectory of Persistent Volume to mount  | `""`                                                |

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -301,7 +301,7 @@ spec:
           readOnly: true
 {{ end }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+{{ toYaml (.Values.resources | default dict) | indent 10 }}
 
 {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -57,8 +57,8 @@ backup:
 
   # Overriding the archive-push/archive-get sections is most useful in
   # very high througput situations. Look at values/high_throuhgput_example.yaml for more details
-  pgBackRest:archive-push: {}
-  pgBackRest:archive-get: {}
+  pgBackRest:archive-push:
+  pgBackRest:archive-get:
   jobs:
       # name: needs to adhere to the kubernetes restrictions
       # type: can be full, incr or diff, see https://pgbackrest.org/user-guide.html
@@ -276,7 +276,7 @@ persistentVolumes:
     # storageClass: "-"
     subPath: ""
     mountPath: "/var/lib/postgresql"
-    annotations: {}
+    annotations:
     accessModes:
       - ReadWriteOnce
   # WAL will be a subdirectory of the data volume, which means enabling a separate
@@ -289,7 +289,7 @@ persistentVolumes:
     # When changing this mountPath ensure you also change the following key to reflect this:
     # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
-    annotations: {}
+    annotations:
     accessModes:
       - ReadWriteOnce
   # Any tablespace mentioned here requires a volume that will be associated with it.
@@ -302,7 +302,7 @@ persistentVolumes:
     #   storageClass: gp2
 
 
-resources: {}
+resources:
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
@@ -339,7 +339,7 @@ timescaledbTune:
   # Therefore you probably want to set explicit overrides in patroni.bootstrap.dcs.postgresql.parameters,
   # as those will take effect as soon as possible.
   # https://github.com/timescale/timescaledb-tune
-  args: {}
+  args:
     # max-conns: 120
     # cpus: 5
     # memory: 4GB
@@ -359,7 +359,7 @@ networkPolicy:
   #      port: 11111
 
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-nodeSelector: {}
+nodeSelector:
 
 # Prometheus exporter for PostgreSQL server metrics.
 # https://github.com/wrouesnel/postgres_exporter
@@ -399,10 +399,10 @@ prometheus:
 
 # Annotations that are applied to each pod in the stateful set
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-podAnnotations: {}
+podAnnotations:
 
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: []
+tolerations:
 
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinityTemplate: |
@@ -424,7 +424,7 @@ affinityTemplate: |
             app: {{ template "timescaledb.fullname" . }}
             release: {{ .Release.Name | quote }}
             cluster-name: {{ template "clusterName" . }}
-affinity: {}
+affinity:
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/


### PR DESCRIPTION
This makes for a better experience IMHO, as previously, if you had
to add the key1: value1 annotation, you would have to:

```diff
- annotations: {}
+ annotations:
+   key1: value1
```

This also allows easier commenting out of things you do/do not want to
enable in the values.yaml

Whereas if we allow nil (and default it correctly in the templates) we
can make this change with the following diff:

```diff
+   key: value1
```