### PR TITLE
Include option to run pgBouncer as a sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ * The possibility to run a [`pgBouncer`](https://www.pgbouncer.org/) container in every Pod.
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -21,61 +21,61 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 
 |       Parameter                   |           Description                       |                         Default                     |
 |-----------------------------------|---------------------------------------------|-----------------------------------------------------|
-| `nameOverride`                    | Override the name of the chart              | `timescaledb`                                       |
+| `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
+| `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname and (availability) zone |
+| `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
+| `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
+| `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
+| `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
+| `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults |
+| `callbacks.configMap`             | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
 | `clusterName`                     | Override the name of the PostgreSQL cluster | Equal to the Helm release name                      |
+| `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)   | `[]`                                                |
+| `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core) | `[]`                                                |
 | `fullnameOverride`                | Override the fullname of the chart          | `nil`                                               |
-| `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
-| `version`                         | The major PostgreSQL version to use         | empty, defaults to the Docker image default         |
+| `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
 | `image.repository`                | The image to pull                           | `timescaledev/timescaledb-ha`                       |
 | `image.tag`                       | The version of the image to pull            | `pg11-ts1.7`                                        |
-| `image.pullPolicy`                | The pull policy                             | `IfNotPresent`                                      |
-| `secretNames.credentials`         | Existing secret that contains env vars that influence Patroni (e.g. PATRONI_SUPERUSER_PASSWORD) | `RELEASE-credentials` | 
-| `secretNames.certificate`         | Existing `type:kubernetes.io/tls` secret containing a tls.key and tls.crt | `RELEASE-certificate` |
-| `secretNames.pgbackrest`          | Existing secret that contains env vars that influence pgBackRest (e.g. PGBACKREST_REPO1_S3_KEY_SECRET) | `RELEASE-pgbackgrest` |
-| `backup.enabled`                  | Schedule backups to occur                   | `false`                                             |
-| `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults |
-| `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
-| `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
-| `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
-| `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)          | `[]`                                                |
-| `envFrom`                         | Extra custom environment variables, expressed as [EnvFrom](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envfromsource-v1-core)          | `[]`                                                |
-| `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
-| `callbacks.configMap`          | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
-| `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
-| `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
-| `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
-| `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
-| `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname and (availability) zone |
-| `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
-| `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
-| `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.annotations`        | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
+| `loadBalancer.enabled`            | If enabled, creates a LB for the primary    | `true`                                              |
 | `loadBalancer.extraSpec`          | Extra configuration for service spec        | `nil`                                               |
-| `networkPolicy.enabled`           | If enabled, creates a NetworkPolicy for controlling network access | `false`
-| `networkPolicy.ingress`           | A list of Ingress rules to extend the base NetworkPolicy | `nil`
+| `nameOverride`                    | Override the name of the chart              | `timescaledb`                                       |
+| `networkPolicy.enabled`           | If enabled, creates a NetworkPolicy for controlling network access | `false`                      |
+| `networkPolicy.ingress`           | A list of Ingress rules to extend the base NetworkPolicy | `nil`                                  |
 | `networkPolicy.prometheusApp`     | Name of Prometheus app to allow it to scrape exporters | `prometheus`
-| `replicaLoadBalancer.enabled`     | If enabled, creates a LB for replica's only | `false`                                             |
-| `replicaLoadBalancer.annotations` | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
-| `replicaLoadBalancer.extraSpec`   | Extra configuration for replica service spec | `nil`                                              |
-| `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
-| `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
-| `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |
-| `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
-| `persistentVolumes.data.enabled`  | If enabled, use a Persistent Data Volume    | `true`                                              |
-| `persistentVolumes.data.mountPath`| Persistent Data Volume mount root path      | `/var/lib/postgresql/`                              |
-| `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume. If disabled, WAL will be on the Data Volume | `true`     |
-| `persistentVolumes.wal.mountPath` | Persistent Wal Volume mount root path       | `/var/lib/postgresql/wal/`                          |
+| `nodeSelector`                    | Node label to use for scheduling            | `{}`                                                |
+| `patroni`                         | Specify your specific [Patroni Configuration](https://patroni.readthedocs.io/en/latest/SETTINGS.html) | A full Patroni configuration |
 | `persistentVolumes.<name>.accessModes` | Persistent Volume access modes         | `[ReadWriteOnce]`                                   |
 | `persistentVolumes.<name>.annotations` | Annotations for Persistent Volume Claim| `{}`                                                |
 | `persistentVolumes.<name>.size`   | Persistent Volume size                      | `2Gi`                                               |
 | `persistentVolumes.<name>.storageClass`| Persistent Volume Storage Class        | `volume.alpha.kubernetes.io/storage-class: default` |
 | `persistentVolumes.<name>.subPath`| Subdirectory of Persistent Volume to mount  | `""`                                                |
+| `persistentVolumes.data.enabled`  | If enabled, use a Persistent Data Volume    | `true`                                              |
+| `persistentVolumes.data.mountPath`| Persistent Data Volume mount root path      | `/var/lib/postgresql/`                              |
 | `persistentVolumes.tablespaces`   | A mapping of tablespaces and Volumes        | `nil`, see [multiple-tablespaces.yaml](values/multiple-tablespaces.yaml) for a full example |
+| `persistentVolumes.wal.enabled`   | If enabled, use a Persistent Wal Volume. If disabled, WAL will be on the Data Volume | `true`     |
+| `persistentVolumes.wal.mountPath` | Persistent Wal Volume mount root path       | `/var/lib/postgresql/wal/`                          |
+| `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
+| `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
+| `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
+| `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |
 | `rbac.create`                     | Create required role and rolebindings       | `true`                                              |
+| `replicaCount`                    | Amount of pods to spawn                     | `3`                                                 |
+| `replicaLoadBalancer.annotations` | Pass on annotations to the Load Balancer    | An AWS ELB annotation to increase the idle timeout  |
+| `replicaLoadBalancer.enabled`     | If enabled, creates a LB for replica's only | `false`                                             |
+| `replicaLoadBalancer.extraSpec`   | Extra configuration for replica service spec | `nil`                                              |
+| `resources`                       | Any resources you wish to assign to the pod | `{}`                                                |
+| `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |
+| `secretNames.certificate`         | Existing `type:kubernetes.io/tls` secret containing a tls.key and tls.crt | `RELEASE-certificate` |
+| `secretNames.credentials`         | Existing secret that contains env vars that influence Patroni (e.g. PATRONI_SUPERUSER_PASSWORD) | `RELEASE-credentials` | 
+| `secretNames.pgbackrest`          | Existing secret that contains env vars that influence pgBackRest (e.g. PGBACKREST_REPO1_S3_KEY_SECRET) | `RELEASE-pgbackgrest` |
 | `serviceAccount.create`           | If true, create a new service account       | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |
+| `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
 | `timescaledbTune.enabled`         | If true, runs `timescaledb-tune` before starting PostgreSQL | `false`                             |
+| `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
 | `unsafe`                          | If true, will generate random a random certificate and random credentials, removing the need for the pre-installation steps with secrets | `false`. This should only be `true` for throw-away (evaluation) deployments |
+| `version`                         | The major PostgreSQL version to use         | empty, defaults to the Docker image default         |
 
 ### Creating the Secrets
 

--- a/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
@@ -1,0 +1,52 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+{{- if .Values.pgBouncer.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "timescaledb.fullname" . }}-pgbouncer
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+    chart: {{ template "timescaledb.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pg_hba.conf: |
+    local     all postgres                   peer
+    host      all postgres,standby 0.0.0.0/0 reject
+    host      all postgres,standby ::0/0     reject
+    hostssl   all all              0.0.0.0/0 md5
+    hostssl   all all              ::0/0     md5
+    hostnossl all all              0.0.0.0/0 reject
+    hostnossl all all              ::0/0     reject
+# The last item specified in the configuration is the one that takes effect with pgBouncer.
+# Therefore, for those items that we deem to be part of how this Helm Chart works, we specify
+# them *after* having listed all the user specified values.
+  pgbouncer-sidecar.ini: |
+    [databases]
+    * =
+    [pgbouncer]
+    {{- $config := .Values.pgBouncer.config | default dict }}
+    {{- range $key := keys $config | sortAlpha }}
+    {{ $key }} = {{ index $config $key }}
+    {{- end }}
+    pidfile = /var/run/postgresql/pgbouncer.pid
+    listen_addr = *
+    listen_port = 6432
+    unix_socket_dir = /var/run/postgresql
+    unix_socket_mode = 0755
+    # We want to protect the superusers as much as we can, we therefore disallow superusers to connect
+    # on many levels, even at this point.
+    # We add the application_name in there to ensure the connections for using pass through authentication
+    # are easily identified
+    auth_query = SELECT rolname, rolpassword FROM pg_catalog.set_config('application_name', 'pgbouncer authentication', false) CROSS JOIN pg_catalog.pg_authid WHERE rolname = $1 AND NOT rolsuper AND NOT rolreplication AND NOT rolbypassrls
+    auth_type = hba
+    auth_hba_file = /etc/pgbouncer/pg_hba.conf
+    auth_user = postgres
+    client_tls_sslmode=require
+    client_tls_key_file = /etc/certificate/tls.key
+    client_tls_cert_file = /etc/certificate/tls.crt
+...
+{{ end }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -204,6 +204,12 @@ spec:
           value: "$(PATRONI_KUBERNETES_POD_IP):5432"
         - name: PATRONI_RESTAPI_CONNECT_ADDRESS
           value: "$(PATRONI_KUBERNETES_POD_IP):8008"
+        - name: PATRONI_KUBERNETES_PORTS
+          {{- if .Values.pgBouncer.enabled }}
+          value: '[{"name": "postgresql", "port": 5432}, {"name": "pgbouncer", "port": 6432}]'
+          {{- else }}
+          value: '[{"name": "postgresql", "port": 5432}]'
+          {{- end }}
         - name: PATRONI_NAME
           valueFrom:
             fieldRef:
@@ -302,6 +308,41 @@ spec:
 {{ end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+
+{{- if .Values.pgBouncer.enabled }}
+      - name: pgbouncer
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              # Only shutdown pgBouncer if PostgreSQL is no longer listening
+              - |
+                while test -S {{ template "socket_directory" . }}/.s.PGSQL.5432; do sleep 1; done
+        volumeMounts:
+          - mountPath: /etc/certificate
+            name: certificate
+            readOnly: true
+          - name: socket-directory
+            mountPath: {{ template "socket_directory" . }}
+            readOnly: false
+          - mountPath: {{ template "scripts_dir" . }}
+            name: timescaledb-scripts
+            readOnly: true
+          - mountPath: /etc/pgbouncer/
+            name: pgbouncer
+            readOnly: true
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+          - containerPort: 6432
+        command:
+        - /usr/bin/env
+        - -i
+        - /usr/sbin/pgbouncer
+        - /etc/pgbouncer/pgbouncer-sidecar.ini
+{{- end }}
 
 {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
@@ -417,6 +458,11 @@ spec:
         emptyDir:
           medium: Memory
       {{- end }}
+      - name: pgbouncer
+        configMap:
+          name: {{ template "timescaledb.fullname" . }}-pgbouncer
+          defaultMode: 416 # 0640 permissions
+          optional: true
       - name: pgbackrest
         configMap:
           name: {{ template "timescaledb.fullname" . }}-pgbackrest

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -417,12 +417,11 @@ spec:
         emptyDir:
           medium: Memory
       {{- end }}
-      {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
         configMap:
           name: {{ template "timescaledb.fullname" . }}-pgbackrest
           defaultMode: 416 # 0640 permissions
-      {{- end }}
+          optional: true
       - name: certificate
         secret:
           secretName:  {{ template "secrets_certificate" . }}

--- a/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb-replica.yaml
@@ -25,6 +25,12 @@ spec:
   type: ClusterIP
 {{- end }}
   ports:
+{{- if .Values.pgBouncer.enabled }}
+  - name: pgbouncer
+    port: {{ .Values.pgBouncer.port }}
+    targetPort: pgbouncer
+    protocol: TCP
+{{- end }}
   - name: postgresql
     # This always defaults to 5432, even if `!replicaLoadBalancer.enabled`.
     port: {{ .Values.replicaLoadBalancer.port }}

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -21,6 +21,12 @@ spec:
   type: ClusterIP
 {{- end }}
   ports:
+{{- if .Values.pgBouncer.enabled }}
+  - name: pgbouncer
+    port: {{ .Values.pgBouncer.port }}
+    targetPort: pgbouncer
+    protocol: TCP
+{{- end }}
   - name: postgresql
     # This always defaults to 5432, even if `!loadBalancer.enabled`.
     port: {{ .Values.loadBalancer.port }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -182,10 +182,6 @@ patroni:
     role_label: role
     scope_label: cluster-name
     use_endpoints: true
-    ports:
-    - name: postgresql
-      port: 5432
-      targetPort: 5432
   postgresql:
     create_replica_methods:
     - pgbackrest
@@ -212,8 +208,9 @@ patroni:
         username: postgres
     listen: 0.0.0.0:5432
     pg_hba:
+    - local     all             postgres                              peer
+    - local     all             all                                   md5
     - hostnossl all,replication all                all                reject
-    - local     all             all                                   peer
     - hostssl   all             all                127.0.0.1/32       md5
     - hostssl   all             all                ::1/128            md5
     - hostssl   replication     standby            all                md5
@@ -353,6 +350,19 @@ timescaledbTune:
     # max-conns: 120
     # cpus: 5
     # memory: 4GB
+
+# pgBouncer does connection pooling for PostgreSQL
+# https://www.pgbouncer.org/
+# enabling pgBouncer will run an extra container in every Pod, serving a pgBouncer
+# pass-through instance
+pgBouncer:
+  enabled: False
+  port: 6432
+  config:
+    server_reset_query: DISCARD ALL
+    max_client_conn: 500
+    default_pool_size: 12
+    pool_mode: transaction
 
 networkPolicy:
   enabled: False


### PR DESCRIPTION
pgBouncer[1] can be very useful in certain environments to limit the
number of connections established, or to limit the number of active
connections to the database.

There are quite a few deployment models for pgBouncer, and it boils down
to the following:

> Q: Should PgBouncer be installed on webserver or database server?
> A: It depends
https://www.pgbouncer.org/faq.html#should-pgbouncer-be-installed-on-webserver-or-database-server

This implementation is chosen, as other implementations can be done
outside of this Helm Chart. This implementation (a sidecar) however
requires to be integrated with the Helm Chart in order to work.

1: https://www.pgbouncer.org
