### PR TITLE
Document that tstune is enabled by default

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `serviceAccount.create`           | If true, create a new service account       | `true`                                              |
 | `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | `nil` |
 | `sharedMemory.useMount`           | Mount `/dev/shm` as a Memory disk           | `false`                                             |
-| `timescaledbTune.enabled`         | If true, runs `timescaledb-tune` before starting PostgreSQL | `false`                             |
+| `timescaledbTune.enabled`         | If true, runs `timescaledb-tune` before starting PostgreSQL | `true`                              |
 | `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
 | `unsafe`                          | If true, will generate random a random certificate and random credentials, removing the need for the pre-installation steps with secrets | `false`. This should only be `true` for throw-away (evaluation) deployments |
 | `version`                         | The major PostgreSQL version to use         | empty, defaults to the Docker image default         |

--- a/charts/timescaledb-single/values/high_throughput.example.yaml
+++ b/charts/timescaledb-single/values/high_throughput.example.yaml
@@ -74,10 +74,6 @@ patroni:
           # remote_apply will throttle the replica's, see also the comment at patroni.bootstrap.synchronous_mode
           synchronous_commit: remote_apply
 
-# Enabling tuning allows us to use this configuration on many types of instances, therefore we enable it
-timescaledbTune:
-  enabled: true
-
 backup:
   enabled: true
 


### PR DESCRIPTION
In commit 162c3838 the default was toggled to true, this brings the
documentation in line with the code.

Fixes GitHub issue #193