### PR TITLE
Use lz4 compression method by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Allow clusters to be initialized from a backup
 ### Changed
  * Use the PostgreSQL 12 Docker Image by default
+ * Use `lz4` compression method by default for pgBackRest
 ### Removed
 ### Fixed
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -27,7 +27,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `backup.jobs`                     | A list of backup schedules and types        | 1 full weekly backup, 1 incremental daily backup    |
 | `backup.pgBackRest:archive-get`   | [pgBackRest global:archive-get configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)  | empty |
 | `backup.pgBackRest:archive-push`  | [pgBackRest global:archive-push configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza) | empty |
-| `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults |
+| `backup.pgBackRest`               | [pgBackRest global configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-stanza)              | Working defaults, using `lz4` compression |
 | `callbacks.configMap`             | A kubernetes ConfigMap containing [Patroni callbacks](#callbacks). You can use templates in the name. | `nil`                         |
 | `clusterName`                     | Override the name of the PostgreSQL cluster | Equal to the Helm release name                      |
 | `env`                             | Extra custom environment variables, expressed as [EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvarsource-v1-core)   | `[]`                                                |

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -46,6 +46,7 @@ backup:
     # https://pgbackrest.org/configuration.html
     # Although not impossible, care should be taken not to include secrets
     # in these parameters. Use Kubernetes Secrets to specify S3 Keys, Secrets etc.
+    compress-type: lz4
     process-max: 4
     start-fast: "y"
     repo1-retention-diff: 2


### PR DESCRIPTION
All recent timescaledb-ha Docker Images have `lz4` available by default,
therefore every (recent) deployment should be able to use this.

This is also supported on existing stanza's:

https://github.com/pgbackrest/pgbackrest/issues/1103