### PR TITLE
Include shellcheck Makefile and CI targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,14 +13,17 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Copy example values files to the expected Helm Linter locations
-        run: |
-          rm -f /charts/timescaledb/ci/*.yaml
-          mkdir -p ./charts/timescaledb-single/ci
-          cd ./charts/timescaledb-single/ci/
-          for f in ../values/*.yaml; do ln -s $f $(basename $f)-values.yaml; done
+        run: make refresh-ci-values
 
-      - name: Run chart-testing (lint)
+      - name: Run linter on Helm Charts
         id: lint
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
+
+      - name: Install shellcheck
+        run: sudo apt-get install shellcheck
+
+      - name: Run shellcheck on all scripts
+        run: make shellcheck
+        if: false # We will enable this once all the scripts are passing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+ * GitHub actions linting the Helm Charts as well as shellcheck the shell scripts
+### Changed
+### Removed
+### Fixed
+
+
 ## [v0.7.0 - 2020-08-14]
 
 The reason for the bump in minor version is that the default PostgreSQL version is changed from 11 to 12,

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 ROGUE_KUSTOMIZE_FILES := $(shell find charts/timescaledb-single/kustomize/ -mindepth 2 -type f ! -path '*kustomize/example*')
 ROGUE_KUSTOMIZE_DIRS := $(shell find charts/timescaledb-single/kustomize/  -mindepth 1 -type d ! -path '*kustomize/example*')
+SINGLE_CHART_DIR := charts/timescaledb-single
+CI_SINGLE_DIR := $(SINGLE_CHART_DIR)/ci/
+SINGLE_VALUES_FILES := $(SINGLE_CHART_DIR)/values.yaml $(wildcard $(SINGLE_CHART_DIR)/values/*.yaml)
 
 .PHONY: publish
 publish: publish-multinode publish-single
@@ -24,7 +27,7 @@ publish-single:
 	helm repo index charts/repo
 
 .PHONY: clean
-clean:
+clean: clean-ci
 	@if [ "$(ROGUE_KUSTOMIZE_FILES)" != "" ]; then rm -v $(ROGUE_KUSTOMIZE_FILES); fi
 	@if [ "$(ROGUE_KUSTOMIZE_DIRS)" != "" ]; then rmdir -v $(ROGUE_KUSTOMIZE_DIRS); fi
 
@@ -32,8 +35,26 @@ clean:
 lint: refresh-ci-values
 	@docker run -it --rm --name ct --volume $$(pwd):/data quay.io/helmpack/chart-testing:v3.0.0 sh -c "ct lint --validate-maintainers=false --charts /data/charts/timescaledb-single /data/charts/timescaledb-multinode"
 
+# We're not symlinking the files, as that generates *a ton* of Helm noise
 .PHONY: refresh-ci-values
-refresh-ci-values:
-	@rm -f ./charts/timescaledb-single/ci/*.yaml
-	@cd ./charts/timescaledb-single/ci; for v in ../values/*.yaml; do ln -s $$v $$(basename $$v)-values.yaml; done; cd -
+refresh-ci-values: clean-ci
+	@cp $(SINGLE_VALUES_FILES) $(CI_SINGLE_DIR)
 
+.PHONY: clean-ci
+clean-ci:
+	@rm -rf ./$(CI_SINGLE_DIR)
+	@mkdir -p ./$(CI_SINGLE_DIR)/
+
+.PHONY: shellcheck shellcheck-single
+shellcheck: shellcheck-single
+shellcheck-single:
+	shellcheck charts/timescaledb-single/generate_kustomization.sh
+	@for vfile in $(SINGLE_VALUES_FILES); do \
+		helm template $(SINGLE_CHART_DIR) -s templates/configmap-scripts.yaml -f $$vfile > $(CI_SINGLE_DIR)/temp.yaml || exit 1 ; \
+		cat $(CI_SINGLE_DIR)/temp.yaml | python3 ./yaml2json.py > $(CI_SINGLE_DIR)/temp.json || exit 1; \
+		for script in $$(jq '.[0].data | keys | sort | .[] | select(endswith(".sh"))' -r $(CI_SINGLE_DIR)/temp.json); do \
+			echo "shellcheck - $$script (from values file $$vfile)" ; \
+			jq ".[0].data.\"$${script}\"" -r $(CI_SINGLE_DIR)/temp.json | shellcheck - --exclude=SC1090 || exit 1; \
+		done ; \
+		rm $(CI_SINGLE_DIR)/temp.* ; \
+	done

--- a/yaml2json.py
+++ b/yaml2json.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import json
+import yaml
+import sys
+
+docs = []
+for doc in yaml.safe_load_all(sys.stdin.read()):
+    if doc:
+        docs.append(doc)
+
+print(json.dumps(docs, indent=4, sort_keys=True))
+


### PR DESCRIPTION
As a lot of things that are being done are in essence shell scripts, it
seems wise to actually lint/check these scripts for all example values
files.

The check is disabled until the time comes that all our scripts conform
to these checks.