### PR TITLE
Prevent WAL disk from filling up

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Run shellcheck on all scripts
         run: make shellcheck
-        if: false # We will enable this once all the scripts are passing
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  * GitHub actions linting the Helm Charts as well as shellcheck the shell scripts
+ * Prevent full WAL disks (experimental, disabled by default)
 ### Changed
 ### Removed
 ### Fixed

--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.7.2
+version: 0.7.3
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -90,6 +90,10 @@ ${HOME}/.pgbackrest_environment
 {{ printf "%s/timescaledb.conf" (include "socket_directory" .) }}
 {{- end -}}
 
+{{- define "wal_status_file" -}}
+{{ printf "%s/wal_status" (include "socket_directory" .) }}
+{{- end -}}
+
 {{- define "secrets_credentials" -}}
 {{ .Values.secretNames.credentials | default (printf "%s-credentials" (include "clusterName" .)) }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -22,12 +22,108 @@ data:
   #
   # Therefore, if the backup is disabled, we always return exitcode 0 when archiving
   pgbackrest_archive.sh: |
-    #!/bin/bash
-    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
-    [ "${PGBACKREST_BACKUP_ENABLED}" == "0" ] && exit 0
+    #!/bin/sh
 
-    source "{{ template "pgbackrest_environment_file" }}"
-    exec pgbackrest --stanza=poddb archive-push "$1"
+    log() {
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - archive - $1"
+    }
+
+    [ -z "$1" ] && log "Usage: $0 <WALFILE or DIRECTORY>" && exit 1
+
+    {{- if .Values.fullWalPrevention.enabled }}
+    prevent_full_wal() {
+        WAL_STATUS_FILE=${WAL_STATUS_FILE:-{{ include "wal_status_file" . }}}
+        WAL_CHECK_INTERVAL=${WAL_CHECK_INTERVAL:-{{ .Values.fullWalPrevention.checkFrequency | default 30 | int }}}
+
+        # Only continue the check if the status file is missing, or if it hasn't been touched in a while
+        if find "${WAL_STATUS_FILE}" -not -newermt "-${WAL_CHECK_INTERVAL} seconds" -exec false {} +; then
+            exit 0
+        fi
+        touch "${WAL_STATUS_FILE}"
+
+        PGDATA=${PGDATA:-.}
+        READ_ONLY_PERCENT=${READ_ONLY_PERCENT:-{{ .Values.fullWalPrevention.thresholds.readOnlyFreePercent | default 5 | int }}}
+        READ_ONLY_MB=${READ_ONLY_MB:-{{ .Values.fullWalPrevention.thresholds.readOnlyFreeMB | default 64 | int }}}
+        READ_WRITE_PERCENT=${READ_WRITE_PERCENT:-{{ .Values.fullWalPrevention.thresholds.readWriteFreePercent | default 7 | int }}}
+        READ_WRITE_MB=${READ_WRITE_MB:-{{ .Values.fullWalPrevention.thresholds.readWriteFreeMB | default 128 | int }}}
+        WAL_STAT=$(stat -L -f --format="%a/%b,%a*%S" "$1")
+        PCT_AVAILABLE=$(( 100*${WAL_STAT%,*} ))
+        MB_AVAILABLE=$(( ${WAL_STAT#*,}/1024/1024 ))
+        if grep -qs "default_transaction_read_only" "${WAL_STATUS_FILE}" "${PGDATA}/postgresql.auto.conf"; then
+            TRANSACTION_READ_ONLY=1
+        else
+            TRANSACTION_READ_ONLY=0
+        fi
+
+        export PGAPPNAME=prevent_full_wal
+        if [ ${TRANSACTION_READ_ONLY} -eq 0 ]; then
+            READ_ONLY_SWITCH=$(( READ_ONLY_PERCENT >= PCT_AVAILABLE || READ_ONLY_MB >= MB_AVAILABLE ))
+            if [ ${READ_ONLY_SWITCH} -ne 0 ]; then
+                log "Switching database to read only to prevent the WAL disk from filling up"
+                psql -q --file - <<__SQL__
+                    ALTER SYSTEM SET default_transaction_read_only to 'on';
+                    SELECT pg_reload_conf();
+
+                    -- By immediately resetting the value, but not reloading the server, we ensure that if the server crashes,
+                    -- or the Pod is rescheduled, the server will switch back to the default: read-write
+                    ALTER SYSTEM RESET default_transaction_read_only;
+
+                    \x on
+                    WITH terminated(session_info, terminate) AS (
+                        SELECT
+                            json_build_object(
+                                'usename', usename,
+                                'datname', datname,
+                                'pid', pid,
+                                'application_name', application_name,
+                                'state', state,
+                                'query_start', query_start
+                            ) AS session_info,
+                            pg_terminate_backend(pid)
+                        FROM
+                            pg_stat_activity
+                        WHERE
+                            datname IS NOT null
+                            AND pid != pg_backend_pid()
+                            AND application_name != 'Patroni'
+                    )
+                    SELECT
+                        'Preventing full WAL disk: Terminated sessions' AS message,
+                        json_agg(session_info) AS terminated_sessions
+                    FROM
+                        terminated
+                    GROUP BY
+                        1;
+
+                    -- A checkpoint might actually solve the out of disk space issue as it may be able to
+                    -- remove WAL segments. At least it ensures a fast recovery if this instance is going to
+                    -- crash/get an ungraceful shutdown.
+                    CHECKPOINT;
+    __SQL__
+                echo "default_transaction_read_only" > "${WAL_STATUS_FILE}"
+            fi
+        else
+            READ_WRITE_SWITCH=$(( READ_WRITE_PERCENT < PCT_AVAILABLE && READ_WRITE_MB < MB_AVAILABLE ))
+            if [ ${READ_WRITE_SWITCH} -ne 0 ]; then
+                log "Resuming read write connections as the WAL disk has enough free space"
+                psql -q --file - <<__SQL__
+                SELECT pg_reload_conf();
+        ALTER SYSTEM RESET default_transaction_read_only;
+        SELECT pg_reload_conf();
+    __SQL__
+                echo > "${WAL_STATUS_FILE}"
+            fi
+        fi
+    }
+
+    prevent_full_wal "$1"
+    {{- end }}
+
+    PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}
+    [ ${PGBACKREST_BACKUP_ENABLED} -ne 0 ] || exit 0
+
+    . "{{ template "pgbackrest_environment_file" }}"
+    exec pgbackrest --stanza=poddb archive-push "$@"
   pgbackrest_archive_get.sh: |
     #!/bin/sh
     PGBACKREST_BACKUP_ENABLED={{ or .Values.backup.enable .Values.backup.enabled | int }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -176,6 +176,7 @@ spec:
             done
 
             touch {{ template "tstune_config" . | quote }}
+            touch {{ template "wal_status_file" . | quote }}
 
             echo "*:*:*:postgres:${PATRONI_SUPERUSER_PASSWORD}" >> ${HOME}/.pgpass
             chmod 0600 ${HOME}/.pgpass

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -326,6 +326,19 @@ persistentVolumes:
     #   size: 5Gi
     #   storageClass: gp2
 
+# EXPERIMENTAL, please do *not* enable on production environments
+# if enabled, fullWalPrevention will switch the default transaction mode from read write
+# to read only if thresholds are breached.
+fullWalPrevention:
+  enabled: false
+  checkFrequency: 30
+  # To prevent the default transaction mode from switching constantly, we have separate
+  # thresholds for switching to read-only and read-write
+  thresholds:
+    readOnlyFreePercent: 5
+    readOnlyFreeMB: 64
+    readWriteFreePercent: 8
+    readWriteFreeMB: 128
 
 resources: {}
   # If you do want to specify resources, uncomment the following


### PR DESCRIPTION
One of the toughest situations to resolve is the WAL Disk running out of
space. To recover from this, you either have to reclaim space, or extend
the volume size and the filesystem.

Extending the volume size is non-trivial in a Kubernetes context, and
reclaiming space is very hard, as WAL segments should never be (re)moved
manually, as they are essential to crash recovery of the PostgreSQL
instance.

(Having the Data Volumes run out of disk space is not that big of an
issue, as PostgreSQL can keep running).

This script and feature adds the possibility to verify that we're not
running out of diskspace for every time the archiver is invoked. By
doing it at that point in time, we can ensure the check is not executed
needlessly frequently on idle clusters, but it does get invoked often
for very write-heavy clusters.

This means that this script - once it has seen some good testing -
should prevent most occurrences of running out of WAL space. Instead of
the PostgreSQL instance not being available at all anymore, it will
still be available for read-only queries, until the time that enough
disk space has been reclaimed. Once the PostgreSQL instance is running,
we can reclaim diskspace in a safe way, for example:
- drop stale replication slot
- fix archiver process
- issue checkpoint

With regards to the choice for bash here: a psql script with variables
would also work, but it will be harder to maintain, as the psql
conditional blocks (\if \endif) are hard to read and not seen that often
in the wild.
I also tried to use a Python script here, as that makes for easier
reading, however the major downside there was that starting the Python
interpreter is an order of magnitude slower than just using bash.