### PR TITLE
Run tests for all pushes

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,9 +1,9 @@
-name: "Helm Lint"
+name: "Test Helm Charts"
 on:
 - push
 
 jobs:
-  smoketest:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,27 +26,31 @@ jobs:
 
       - name: Run shellcheck on all scripts
         run: make shellcheck
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Test if Chart.yaml has been touched
+        id: single_chart_changed
+        run: echo "::set-output name=changes::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} charts/timescaledb-single/Chart.yaml)"
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.single_chart_changed.outputs.changes != ''
 
       - uses: azure/setup-kubectl@v1
         id: install-kubectl
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.single_chart_changed.outputs.changes != ''
 
       - uses: azure/setup-helm@v1
         id: install-helm
-        if: steps.lint.outputs.changed == 'true'
+        if: steps.single_chart_changed.outputs.changes != ''
 
-      - name: Install a cluster
-        run: make install-example
-        if: steps.lint.outputs.changed == 'true'
-
-      - name: Wait for a primary to be available
-        run: make wait-for-example
-        if: steps.lint.outputs.changed == 'true'
-
-      - name: Verify that we can create a hypertable
-        run: make smoketest
-        if: steps.lint.outputs.changed == 'true'
+      - name: Test all available values files clusters
+        run: make test
+        if: steps.single_chart_changed.outputs.changes != ''

--- a/tests/values.yaml
+++ b/tests/values.yaml
@@ -1,0 +1,34 @@
+replicaCount: 2
+secretNames:
+  credentials: example-credentials
+  certificate: example-certificate
+  pgbackrest: example-pgbackrest
+
+patroni:
+  postgresql:
+    parameters:
+      shared_buffers: 4MB # We're not testing Postgres, we're testing the Charts
+      min_wal_size: 600MB # We need to be able to have at least 2 256MB WAL segments
+
+persistentVolumes:
+  data:
+    size: 1G
+  wal:
+    size: 1G
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+backup:
+  enabled: false
+
+# We disable the readinessProbe to speed up the provisioning of the replica
+# Normally, having the deployment increase the pod count gradually is great,
+# during testing however, we're happy to go as quickly as possible.
+readinessProbe:
+  enabled: false

--- a/tests/verify_deployment.sh
+++ b/tests/verify_deployment.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 VALUES_FILE [DEPLOYMENT_NAME]"
+fi
+
+SCRIPTDIR="$(dirname "$0")"
+SINGLE_CHART_DIR=${SINGLE_CHART_DIR:-./charts/timescaledb-single}
+TEST_REPLICA=${TEST_REPLICA:-1}
+PULL_TIMEOUT=${PULL_TIMEOUT:-600s}
+DEPLOYMENT_TIMEOUT=${DEPLOYMENT_TIMEOUT:-180s}
+DELETE_DEPLOYMENT=${DELETE_DEPLOYMENT:-1}
+
+deployment_name() {
+    basename "${1%".yaml"}" | tr '.' '-' | tr '_' '-' | cut -c 1-30
+}
+
+undeploy() {
+    if [ "${DELETE_DEPLOYMENT}" -eq 1 ]; then
+        helm delete "$1"
+    fi
+}
+
+deploy() {
+    helm upgrade --install "$1" "${SINGLE_CHART_DIR}" -f "$2" -f "${SCRIPTDIR}/values.yaml" > /dev/null || exit 1
+}
+
+wait_for_docker() {
+    ## We will wait for the first pod to be initialized; we do this, as on a pristine cluster
+    ## most of the time may be spent pulling a Docker Image.
+    echo "Waiting for first Pod to be initialized (docker pull completed)"
+    if ! kubectl wait --timeout="${PULL_TIMEOUT}" --for=condition=initialized "pod/${1}-timescaledb-0"; then
+        echo "Timed out waiting for docker image pull"
+        undeploy "${DEPLOYMENT}"
+        exit 1
+    fi
+}
+
+test_deploy() {
+    DEPLOYMENT="$1"
+    ## By using a Job instead of relying on tools on the system that is running the tests, we verify at least
+    ## the following:
+    ##  * There is a primary running
+    ##  * There is a primary service pointing to the primary
+    ##  * There is a replica running
+    ##  * There is a replica service pointing to the replica(s)
+    ##  * The password set is valid for both the primary and the replica
+    ##  * Inserting data works on the primary
+    ##  * TimescaleDB is installed and can create hypertables
+    ##  * Changes made on the primary propagate to (at least one) replica
+    JOBNAME="${DEPLOYMENT}"
+    kubectl delete "job/${JOBNAME}" > /dev/null 2>&1
+    ## Poor man's kustomize, for now, this seems adequate for its purposes though
+    sed "s/example\$/${DEPLOYMENT}/g; s/TEST_REPLICA, value: \".*\"/TEST_REPLICA, value: \"${TEST_REPLICA}\"/g" "${SCRIPTDIR}/wait_for_example_job.yaml" \
+      | kubectl apply -f -
+
+    echo "Waiting for deployment \"${JOBNAME}\" to complete ..."
+    if ! kubectl wait --timeout="${DEPLOYMENT_TIMEOUT}" --for=condition=complete "job/${JOBNAME}"; then
+        echo "===================================================="
+        echo " ERROR: deployment ${DEPLOYMENT}, details:"
+        echo "===================================================="
+        kubectl get pod,ep,configmap,service -l app="${DEPLOYMENT}-timescaledb"
+        echo "...................................................."
+        kubectl describe "pod/${DEPLOYMENT}-timescaledb-0"
+        kubectl logs "pod/${DEPLOYMENT}-timescaledb-0" -c timescaledb
+        echo "...................................................."
+        kubectl describe "pod/${DEPLOYMENT}-timescaledb-1"
+        kubectl logs "pod/${DEPLOYMENT}-timescaledb-1" -c timescaledb
+        echo "...................................................."
+        kubectl logs "job/${JOBNAME}"
+        echo "===================================================="
+        undeploy "${DEPLOYMENT}"
+        exit 1
+    fi
+    echo "===================================================="
+    echo " OK: deployment ${DEPLOYMENT}"
+    echo "===================================================="
+}
+
+
+VALUES_FILE="$1"
+shift
+if [ -z "$1" ]; then
+    DEPLOYMENT="$(basename "${VALUES_FILE%".yaml"}" | tr '.' '-' | tr '_' '-')"
+else
+    DEPLOYMENT="$1"
+fi
+
+terminate() {
+    echo "Terminating verification of deployment ${DEPLOYMENT}"
+    exit 1
+}
+trap terminate TERM QUIT
+
+deploy "${DEPLOYMENT}" "${VALUES_FILE}"
+wait_for_docker "${DEPLOYMENT}"
+test_deploy "${DEPLOYMENT}"
+undeploy "${DEPLOYMENT}"

--- a/tests/wait_for_example_job.yaml
+++ b/tests/wait_for_example_job.yaml
@@ -1,0 +1,93 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: example
+spec:
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      name: example
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: waiter
+        image: timescaledev/timescaledb-ha:pg12-ts1.7-latest
+        resources:
+          limits:
+            cpu: 100m
+            memory: 24Mi
+          requests:
+            cpu: 100m
+            memory: 24Mi
+        env:
+        - {name: TEST_REPLICA, value: "1"}
+        - name: PGHOST
+          value: example
+        - name: PGUSER
+          value: postgres
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: example-credentials
+              key: PATRONI_SUPERUSER_PASSWORD
+        command:
+        - /bin/sh
+        - '-c'
+        - |
+
+          log() {
+              echo "$(date --iso-8601=seconds) - $1"
+          }
+
+          terminate() {
+              exit 1
+          }
+          trap terminate TERM QUIT
+
+          while sleep 10; do
+              # This will throw an error if the primary does not yet accept writes
+              psql -X -f - --set ON_ERROR_STOP=1 -c "CREATE TEMPORARY TABLE a AS SELECT 1" > /dev/null 2>&1 && break
+              log "Waiting for deployment \"${PGHOST}\" (primary) to become available"
+          done
+
+
+          NOW="$(date --iso-8601=seconds)"
+          psql -Xq -f - --set ON_ERROR_STOP=1 <<__SQL__
+              \x on
+              CREATE SCHEMA IF NOT EXISTS citest;
+              DROP TABLE IF EXISTS citest.demo;
+              CREATE TABLE citest.demo(inserted timestamptz not null);
+              SELECT * FROM create_hypertable('citest.demo', 'inserted');
+              INSERT INTO citest.demo VALUES ('${NOW}') RETURNING *;
+          __SQL__
+          EXITCODE=$?
+          if [ "${EXITCODE}" -ne 0 ]; then exit "${EXITCODE}"; fi
+
+
+          if [ "${TEST_REPLICA}" -eq 1 ]; then
+              export PGHOST="${PGHOST}-replica"
+
+              while sleep 3; do
+                  # This will throw a divide by zero error as long as the record has not been replicated
+                  psql -X -f - --set ON_ERROR_STOP=1 -c "SELECT 1/count(*) FROM citest.demo WHERE inserted = '${NOW}'" > /dev/null 2>&1 && break
+                  log "Waiting for deployment \"${PGHOST}\" (replica) to become available"
+              done
+
+              psql -Xq -f - --set ON_ERROR_STOP=1 <<__SQL__
+                  \x on
+                  SELECT now(), * FROM pg_stat_wal_receiver;
+                  SELECT * FROM citest.demo WHERE inserted = '${NOW}';
+                  SELECT count(*) > 0 AS replica_ok FROM citest.demo WHERE inserted = '${NOW}'
+                  \gset
+                  \if :replica_ok
+                      SELECT 'Replica caught up with primary';
+                  \else
+                      SELECT 'Could not find the test record on the replica';
+                      SELECT 1/0; -- this will cause the script to exit with a failure
+                  \endif
+          __SQL__
+              EXITCODE=$?
+              if [ "${EXITCODE}" -ne 0 ]; then exit "${EXITCODE}"; fi
+          fi
+
+          log "Everything seems fine with deployment ${PGHOST}"


### PR DESCRIPTION
    Introducing these tests gives us reasonable confidence that we're not
    introducing a major error with the primary purpose of these Helm Charts:
    to deploy a working set of Patroni managed PostgreSQL members.
    
    The linter runs on every push, whereas the more extensive test, which
    spins up all known values files, is only triggered if the Chart.yaml has
    been changed in preparation of a release.

