### PR TITLE
Refactors pgbouncer configmap

### DIFF
--- a/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
@@ -21,17 +21,10 @@ data:
     hostssl   all all              ::0/0     md5
     hostnossl all all              0.0.0.0/0 reject
     hostnossl all all              ::0/0     reject
-# The last item specified in the configuration is the one that takes effect with pgBouncer.
-# Therefore, for those items that we deem to be part of how this Helm Chart works, we specify
-# them *after* having listed all the user specified values.
   pgbouncer-sidecar.ini: |
     [databases]
     * =
     [pgbouncer]
-    {{- $config := .Values.pgBouncer.config | default dict }}
-    {{- range $key := keys $config | sortAlpha }}
-    {{ $key }} = {{ index $config $key }}
-    {{- end }}
     pidfile = /var/run/postgresql/pgbouncer.pid
     listen_addr = *
     listen_port = 6432
@@ -48,5 +41,11 @@ data:
     client_tls_sslmode=require
     client_tls_key_file = /etc/certificate/tls.key
     client_tls_cert_file = /etc/certificate/tls.crt
+    # Loading these last, to allow for overriding of any of the above defaults. Since the 
+    # last instance of an option gets used. Exercise caution overriding any of the above.
+    {{- $config := .Values.pgBouncer.config | default dict }}
+    {{- range $key := keys $config | sortAlpha }}
+    {{ $key }} = {{ index $config $key }}
+    {{- end }}
 ...
 {{ end }}

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -390,6 +390,13 @@ pgBouncer:
   enabled: false
   port: 6432
   config:
+  # DANGER: The below settings are considered to be safe to set, and we recommend
+  # you do set these to appropriate values for you.
+  # However, for flexibility, we do allow the override of any pg_bouncer setting
+  # many of which are vital to the operation of this helm chart.
+  # The values we do not suggest altering are set in the template
+  # https://github.com/timescale/timescaledb-kubernetes/blob/master/charts/timescaledb-single/templates/configmap-pgbouncer.yaml#L35-L50
+  # Only override these settings if you are confident of  what you are doing.
     server_reset_query: DISCARD ALL
     max_client_conn: 500
     default_pool_size: 12


### PR DESCRIPTION
This is a minor refactor, putting the configmap values from the values.yaml at the END of the block instead of the beginning.
This allows for overriding of all options, specifically of importance is auth_query.

The reason for this is pgbouncer uses the last instance of a given configuration key, so in the orignial structure, adding an auth_query to the values.yaml resulted in that setting getting ignored, using the default from the template.
The same was true for all template-provided defaults.