### PR TITLE
use named port for pgbouncer

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -341,6 +341,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
           - containerPort: 6432
+            name: pgbouncer
         command:
         - /usr/bin/env
         - -i


### PR DESCRIPTION
The services(s) call for `targetPort: pgbouncer` but the sts does not currently define that name. This leads to the endpoint not getting computed, and it causes issues with service loadbalancers.