### PR TITLE
Add resources to init container

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -112,6 +112,8 @@ spec:
         volumeMounts:
         - name: socket-directory
           mountPath: {{ template "socket_directory" . }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
 {{- end }}
       # Issuing the final checkpoints on a busy database may take considerable time.
       # Unfinished checkpoints will require more time during startup, so the tradeoff


### PR DESCRIPTION
When you have quota on a namespace then try to add a timescaleDB in it, it will fail because of missing resources in init container.
Idk if you prefer to use same resources configuration than containers, if yes, there is the PR