### PR TITLE
Explicitly configure securityContext for pod

### DIFF
--- a/charts/timescaledb-multinode/templates/_helpers.tpl
+++ b/charts/timescaledb-multinode/templates/_helpers.tpl
@@ -37,6 +37,10 @@ If release name contains chart name it will be used as a full name.
 {{ template "timescaledb.fullname" . }}-access
 {{- end -}}
 
+{{- define "postgres.uid" -}}
+{{- default .Values.uid "1000" -}}
+{{- end -}}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/timescaledb-multinode/templates/statefulset-timescaledb-accessnode.yaml
+++ b/charts/timescaledb-multinode/templates/statefulset-timescaledb-accessnode.yaml
@@ -30,9 +30,14 @@ spec:
       securityContext:
         # The postgres user inside the TimescaleDB image has uid=1000.
         # This configuration ensures the permissions of the mounts are suitable
-        fsGroup: 1000
+        fsGroup: {{ template "postgres.uid" }}
+        runAsGroup:  {{ template "postgres.uid" }}
+        runAsNonRoot: true
+        runAsUser:  {{ template "postgres.uid" }}
       initContainers:
       - name: initdb
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -79,6 +84,8 @@ spec:
           subPath: "{{ .Values.persistentVolume.subPath }}"
       containers:
       - name: timescaledb
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # We start postgres with a fully cleared environment

--- a/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
+++ b/charts/timescaledb-multinode/templates/statefulset-timescaledb-datanode.yaml
@@ -30,9 +30,14 @@ spec:
       securityContext:
         # The postgres user inside the TimescaleDB image has uid=1000.
         # This configuration ensures the permissions of the mounts are suitable
-        fsGroup: 1000
+        fsGroup: {{ template "postgres.uid" }}
+        runAsGroup: {{ template "postgres.uid" }}
+        runAsNonRoot: true
+        runAsUser:  {{ template "postgres.uid" }}
       initContainers:
       - name: initdb
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
@@ -74,6 +79,8 @@ spec:
           subPath: "{{ .Values.persistentVolume.subPath }}"
       containers:
       - name: timescaledb
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # We start postgres with a fully cleared environment

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -66,6 +66,10 @@ ${HOME}/.pgbackrest_environment
 /etc/pgbackrest/bootstrap
 {{- end -}}
 
+{{- define "postgres.uid" -}}
+{{- default .Values.uid "1000" -}}
+{{- end -}}
+
 {{- define "data_directory" -}}
 {{ printf "%s/data" .Values.persistentVolumes.data.mountPath }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -36,10 +36,15 @@ spec:
       securityContext:
         # The postgres user inside the TimescaleDB image has uid=1000.
         # This configuration ensures the permissions of the mounts are suitable
-        fsGroup: 1000
+        fsGroup: {{ template "postgres.uid" }}
+        runAsGroup: {{ template "postgres.uid" }}
+        runAsNonRoot: true
+        runAsUser: {{ template "postgres.uid" }}
       initContainers:
 {{- if .Values.timescaledbTune.enabled }}
       - name: tstune
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         env:
         - name: TSTUNE_FILE
@@ -121,6 +126,8 @@ spec:
       terminationGracePeriodSeconds: 600
       containers:
       - name: timescaledb
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         lifecycle:
@@ -315,6 +322,8 @@ spec:
 
 {{- if .Values.pgBouncer.enabled }}
       - name: pgbouncer
+        securityContext:
+          allowPrivilegeEscalation: false
         lifecycle:
           preStop:
             exec:
@@ -351,6 +360,8 @@ spec:
 
 {{- if or .Values.backup.enabled .Values.backup.enable }}
       - name: pgbackrest
+        securityContext:
+          allowPrivilegeEscalation: false
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
@@ -404,7 +415,7 @@ spec:
         image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
         imagePullPolicy: {{ .Values.prometheus.image.pullPolicy }}
         securityContext:
-          runAsUser: 1000
+          allowPrivilegeEscalation: false
         ports:
         - containerPort: 9187
         volumeMounts:


### PR DESCRIPTION
By setting the Pod SecurityContext, we ensure every container inherits
these settings. The only field that cannot be set at the Pod level is
`allowPrivilegeEscalation`, therefore, we set that at the container
level.

By making the uid a template (which derives from values) we can more
easily set a different uid for all the processes involved.

Addresses issue #240.

https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core
https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core