### PR TITLE
Refactor some pgBouncer features

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -58,6 +58,8 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `pgBouncer.config`                | Additional pgBouncer [configuration](https://www.pgbouncer.org/config.html) items | A reasonable set of defaults |
 | `pgBouncer.enabled`               | If enabled, run a [pgBouncer](https://www.pgbouncer.org/) sidecar | `false`                       |
 | `pgBouncer.port`                  | The port on which the Load Balancer should listen for pgBouncer requests | `6432`                 |
+| `pgBouncer.pg_hba`                | The `pg_hba` to be used by pgBouncer        | A `pg_hba` allowing non-superuser ssl-only connections |
+| `pgBouncer.userListSecretName`    | If set, a [user authentication file](https://www.pgbouncer.org/config.html#authentication-file-format) to be used by pgBouncer. | `nil` |
 | `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
 | `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
 | `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |

--- a/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbouncer.yaml
@@ -14,8 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   pg_hba.conf: |
-{{ tpl .Values.pgBouncer.pg_hba . | indent 4 }}
-
+  {{- range $hba := (.Values.pgBouncer.pg_hba | default (list "local all all peer")) }}
+    {{ $hba }}
+  {{- end }}
   pgbouncer-sidecar.ini: |
     [databases]
     * =

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -510,12 +510,26 @@
           "default": false,
           "type": "boolean"
         },
+        "pg_hba": {
+          "description": "The pg_hba configuration that will be used by pgBouncer\n",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "port": {
           "default": 6432,
           "enum": [
             6432
           ],
           "type": "integer"
+        },
+        "userListSecretName": {
+          "description": "A pointer to a SecretName containing user/password pairs in the format expected by pgbouncer\nhttps://www.pgbouncer.org/config.html#authentication-file-format\n",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "type": "object"

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -378,6 +378,19 @@ properties:
       enabling pgBouncer will run an extra container in every Pod, serving a pgBouncer
       pass-through instance
     properties:
+      pg_hba:
+        description: |
+          The pg_hba configuration that will be used by pgBouncer
+        type: array
+        items:
+          type: string
+      userListSecretName:
+        description: |
+          A pointer to a SecretName containing user/password pairs in the format expected by pgbouncer
+          https://www.pgbouncer.org/config.html#authentication-file-format
+        type:
+        - string
+        - "null"
       enabled:
         type: boolean
         default: false

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -401,14 +401,14 @@ pgBouncer:
     max_client_conn: 500
     default_pool_size: 12
     pool_mode: transaction
-  pg_hba: |
-    local     all postgres                   peer
-    host      all postgres,standby 0.0.0.0/0 reject
-    host      all postgres,standby ::0/0     reject
-    hostssl   all all              0.0.0.0/0 md5
-    hostssl   all all              ::0/0     md5
-    hostnossl all all              0.0.0.0/0 reject
-    hostnossl all all              ::0/0     reject
+  pg_hba:
+  - local     all postgres                   peer
+  - host      all postgres,standby 0.0.0.0/0 reject
+  - host      all postgres,standby ::0/0     reject
+  - hostssl   all all              0.0.0.0/0 md5
+  - hostssl   all all              ::0/0     md5
+  - hostnossl all all              0.0.0.0/0 reject
+  - hostnossl all all              ::0/0     reject
   # Secret should contain user/password pairs in the format expected by pgbouncer
   # https://www.pgbouncer.org/config.html#authentication-file-format
   # example:


### PR DESCRIPTION
Made the pgBouncer pg_hba into a list, as that is also how the Patroni
pg_hba is configured. It would be confusing if in the same `values.yaml`
there would be 2 separate ways of configuring the same category of
thing.

Added schema and documentation for these new pgBouncer configuration
items.