### PR TITLE
Multi node chart updates

### DIFF
--- a/charts/timescaledb-multinode/admin-guide.md
+++ b/charts/timescaledb-multinode/admin-guide.md
@@ -30,6 +30,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `tolerations`                     | List of node taints to tolerate             | `[]`                                                |
 | `affinityTemplate`                | A template string to use to generate the affinity settings | Anti-affinity preferred on hostname  |
 | `affinity`                        | Affinity settings. Overrides `affinityTemplate` if set. | `{}`                                    |
+| `loadBalancer.enabled`            | If enabled, creates a LB for the access node| `true`                                              |
 | `postgresql.databases`            | List of databases to automatically create a multinode setup for | `["postgres", "example"]`       |
 | `postgresql.parameters`           | [PostgreSQL parameters](https://www.postgresql.org/docs/current/config-setting.html#CONFIG-SETTING-CONFIGURATION-FILE)) | Some required and preferred settings |
 | `schedulerName`                   | Alternate scheduler name                    | `nil`                                               |

--- a/charts/timescaledb-multinode/templates/NOTES.txt
+++ b/charts/timescaledb-multinode/templates/NOTES.txt
@@ -4,25 +4,32 @@
 TimescaleDB can be accessed via port 5432 on the following DNS name from within your cluster:
 {{ template "timescaledb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
-To get your password for superuser run:
+To get your password for superuser on the access node run:
+    # access node superuser password
+    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "timescaledb.fullname" . }}-access -o jsonpath="{.data.password-superuser}" | base64 --decode)
 
-    # superuser password
-    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "timescaledb.fullname" . }} -o jsonpath="{.data.password-superuser}" | base64 --decode)
-
-    # admin password
-    PGPASSWORD_ADMIN=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "timescaledb.fullname" . }} -o jsonpath="{.data.password-admin}" | base64 --decode)
 
 To connect to your database:
 
-1. Run a postgres pod and connect using the psql cli:
+Run a postgres pod and connect using the psql cli:
+
     # login as superuser
     kubectl run -i --tty --rm psql --image=postgres \
       --env "PGPASSWORD=$PGPASSWORD_SUPERUSER" \
       --command -- psql -U postgres \
       -h {{ template "timescaledb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
 
-    # login as admin
-    kubectl run -i -tty --rm psql --image=postgres \
-      --env "PGPASSWORD=$PGPASSWORD_ADMIN" \
-      --command -- psql -U admin \
-      -h {{ template "timescaledb.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local postgres
+Connect to the database from your local machine:
+
+1. Get the password for access node
+    PGPASSWORD_SUPERUSER=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "timescaledb.fullname" . }}-access -o jsonpath="{.data.password-superuser}" | base64 --decode)
+
+2. Get the name of the access node pod
+    ACCESS_NODE_POD=$(kubectl get pod -o name --namespace {{ .Release.Namespace }} -l release={{ .Release.Name }},timescaleNodeType=access)
+
+3. Start a port forward from the access node
+    kubectl port-forward $ACCESS_NODE_POD 7000:5432 -n=default
+
+4. Now you can access the database that’s in your cluster as if it were running locally.
+Use whatever port you’re forwarding to (7000 in this case). The host is localhost, the user 
+is postgres and the password is $PGPASSWORD_SUPERUSER from step one

--- a/charts/timescaledb-multinode/templates/svc-timescaledb-access.yaml
+++ b/charts/timescaledb-multinode/templates/svc-timescaledb-access.yaml
@@ -14,7 +14,11 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"
 spec:
+{{- if .Values.loadBalancer.enabled }}
   type: LoadBalancer
+{{- else }}
+  type: ClusterIP
+{{- end }}
   ports:
   - name: postgresql
     port: 5432

--- a/charts/timescaledb-multinode/values.yaml
+++ b/charts/timescaledb-multinode/values.yaml
@@ -10,8 +10,8 @@ nameOverride: timescaledb
 image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
-  repository: timescaledev/timescaledb-ha
-  tag: pg12-ts2.0.0-p0
+  repository: timescale/timescaledb-ha
+  tag: pg12.5-ts2.0.0-p0
   pullPolicy: IfNotPresent
 
 # Credentials used by PostgreSQL

--- a/charts/timescaledb-multinode/values.yaml
+++ b/charts/timescaledb-multinode/values.yaml
@@ -121,3 +121,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+# Disabling Load Balancer will create a `ClusterIP` type service for the access node
+loadBalancer:
+  enabled: true


### PR DESCRIPTION
Made three changes:

1. Changed the default repository used in chart. The current one doesn't work get an error about not being able to use `add_data_node` on the Apache License

2. Added option to enable/disable loadbalancer

3. Fixed up some stuff in the NOTES.TXT that gets displayed after the user deploys
    
   - Fixed secret name
   - Added section about using `kubectl port-forward`
   - 