### PR TITLE
Add checksum annotations of config maps to trigger deployment when ConfigMap changes

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -28,8 +28,13 @@ spec:
         app: {{ template "timescaledb.fullname" . }}
         release: {{ .Release.Name }}
         cluster-name: {{ template "clusterName" . }}
-{{- if .Values.podAnnotations }}
       annotations:
+        checksum/config-pgbackrest: {{ include (print $.Template.BasePath "/configmap-pgbackrest.yaml") . | sha256sum }}
+        checksum/config-patroni: {{ include (print $.Template.BasePath "/configmap-patroni.yaml") . | sha256sum }}
+{{- if .Values.pgBouncer.enabled }}
+        checksum/config-pgbouncer: {{ include (print $.Template.BasePath "/configmap-pgbouncer.yaml") . | sha256sum }}
+{{- end}}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:


### PR DESCRIPTION
I noticed when I was updating the config file of PgBackRest, and used `helm upgrade`, that the pods did not restart with the changes.
Adding these annotations will trigger a redeploy when one of the following ConfigMap changes:

- pgbackrest
- patroni
- pgbouncer (if enabled)

I explicitly did not add the scripts ConfigMap, as I think it is not necessary. Correct me if I'm wrong.