### PR TITLE
Update helm command to remove name option

### DIFF
--- a/charts/timescaledb-single/README.md
+++ b/charts/timescaledb-single/README.md
@@ -113,7 +113,7 @@ chart itself.
 * And install the chart:
 
   ```console
-  helm install --name my-release .
+  helm install my-release .
   ```
 
 To keep the repo up to date with new versions you can do:


### PR DESCRIPTION
Got the below error while running the command from instructions. Checked the [helm install docs](https://helm.sh/docs/helm/helm_install/) and looks like there is no explicit name flag in newer versions. Removed the --name part and it ran without errors

helm install [NAME] [CHART] [flags]

### Before 
  │  ~/c/h/timescaledb-single  helm install --namespace tsdb  --name tsdbtraining .                                                        
Error: unknown flag: --name

### After
  │  ~/cloud/helmcharts/timescaledb-single  helm install --namespace tsdb  tsdbtraining .                                                        
NAME: tsdbtraining
