### PR TITLE
Use label selector to find pod with role=master

### DIFF
--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -15,6 +15,12 @@ metadata:
   annotations:
 {{ .Values.loadBalancer.annotations | toYaml | indent 4 }}
 spec:
+{{- if not .Values.patroni.kubernetes.use_endpoints }}
+  selector:
+    app: {{ template "timescaledb.fullname" . }}
+    cluster-name: {{ template "clusterName" . }}
+    role: master
+{{- end -}}
 {{- if .Values.loadBalancer.enabled }}
   type: LoadBalancer
 {{- else }}


### PR DESCRIPTION
When run under Kubernetes, Patroni normally updates the Endpoints of a Service so the current-master node is discoverable by connecting to that Service.

When patroni.kubernetes.use_endpoints=false, this functionality is disabled, and nothing creates those Endpoints. This leaves the current-master difficult to discover.

However, both role=master and role=replica labels are updated on the pods. The role=replica label selector is already used in the `RELEASENAME-replica` Service. Use the role=master label selector in the `RELEASENAME` Service too, when patroni.kubernetes.use_endpoints=false.

Fixes issue https://github.com/timescale/timescaledb-kubernetes/issues/278 