### PR TITLE
Update README.md - change my_release to my-release

### DIFF
--- a/charts/timescaledb-single/README.md
+++ b/charts/timescaledb-single/README.md
@@ -98,7 +98,7 @@ chart itself.
 
   ```console
   cd ./timescaledb-single
-  bash ./generate_kustomization.sh my_release
+  bash ./generate_kustomization.sh my-release
   ```
 
   The script will generate configuration for


### PR DESCRIPTION
Underscores are not supported by kubernetes, so generating names with "my_release" prefix breaks the installation on the apply to kubernetes step. It looks like a simple typo as in the next commands hyphen is used instead of underscore.