### PR TITLE
Upgrade postgres-exporter to latest version

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the TimescaleDB Helm ch
 | `pgBouncer.pg_hba`                | The `pg_hba` to be used by pgBouncer        | A `pg_hba` allowing non-superuser ssl-only connections |
 | `pgBouncer.userListSecretName`    | If set, a [user authentication file](https://www.pgbouncer.org/config.html#authentication-file-format) to be used by pgBouncer. | `nil` |
 | `podManagementPolicy`             | Either [`OrderedReady` or `Parallel`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) | `OrderedReady` |
-| `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/wrouesnel/postgres_exporter) sidecar | `false` |
+| `prometheus.enabled`              | If enabled, run a [postgres\_exporter](https://github.com/prometheus-community/postgres_exporter) sidecar | `false` |
 | `prometheus.image.pullPolicy`     | The pull policy for the postgres\_exporter  | `IfNotPresent`                                      |
 | `prometheus.image.repository`     | The postgres\_exporter docker repo          | `wrouesnel/postgres_exporter`                       |
 | `prometheus.image.tag`            | The tag of the postgres\_exporter image     | `v0.7.0`                                            |

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -448,12 +448,12 @@ networkPolicy:
 nodeSelector: {}
 
 # Prometheus exporter for PostgreSQL server metrics.
-# https://github.com/wrouesnel/postgres_exporter
+# https://github.com/prometheus-community/postgres_exporter
 prometheus:
   enabled: false
   image:
-    repository: wrouesnel/postgres_exporter
-    tag: v0.7.0
+    repository: prometheuscommunity/postgres-exporter
+    tag: v0.9.0
     pullPolicy: Always
   # Extra custom environment variables for prometheus.
   # These should be an EnvVar, as this allows you to inject secrets into the environment


### PR DESCRIPTION
At some point the `wrouesnel/postgres_exporter` repository was handed over to the `prometheus-community` org. This chart is still using the old Docker image (and missing out on lots of [new metrics](https://github.com/prometheus-community/postgres_exporter/compare/v0.7.0...v0.9.0)).

I've deployed this with the latest Helm chart and it's working well, no other changes need to be made