### PR TITLE
fixed default uid syntax in helpers.tpl

### DIFF
--- a/charts/timescaledb-multinode/templates/_helpers.tpl
+++ b/charts/timescaledb-multinode/templates/_helpers.tpl
@@ -38,7 +38,7 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "postgres.uid" -}}
-{{- default .Values.uid "1000" -}}
+{{- default "1000" .Values.uid -}}
 {{- end -}}
 
 {{/*

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -67,7 +67,7 @@ ${HOME}/.pgbackrest_environment
 {{- end -}}
 
 {{- define "postgres.uid" -}}
-{{- default .Values.uid "1000" -}}
+{{- default "1000" .Values.uid -}}
 {{- end -}}
 
 {{- define "data_directory" -}}


### PR DESCRIPTION
The parameters were flipped. This should allow setting `uid` in `values.yaml` and help with #72.