### PR TITLE
charts: preserve secrets when upgrading chart in unsafe mode

### DIFF
--- a/charts/timescaledb-single/templates/unsafe_credentials.yaml
+++ b/charts/timescaledb-single/templates/unsafe_credentials.yaml
@@ -14,9 +14,15 @@ metadata:
     "helm.sh/hook": pre-install
 type: Opaque
 data:
+{{- if .Release.IsUpgrade }}
+  PATRONI_SUPERUSER_PASSWORD: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.credentials).data "PATRONI_SUPERUSER_PASSWORD" }}
+  PATRONI_REPLICATION_PASSWORD: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.credentials).data "PATRONI_REPLICATION_PASSWORD" }}
+  PATRONI_admin_PASSWORD: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.credentials).data "PATRONI_admin_PASSWORD" }}
+{{ else }}
   PATRONI_SUPERUSER_PASSWORD: {{ randAlphaNum 16 | b64enc }}
   PATRONI_REPLICATION_PASSWORD: {{ randAlphaNum 16 | b64enc }}
   PATRONI_admin_PASSWORD: {{ randAlphaNum 16 | b64enc }}
+{{ end }}
 ...
 ---
 {{ $ca := genCA (include "clusterName" .) 1826 -}}
@@ -31,8 +37,13 @@ metadata:
     "helm.sh/hook": pre-install
 type: kubernetes.io/tls
 data:
+{{- if .Release.IsUpgrade }}
+  tls.crt: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.certificate).data "tls.crt" }}
+  tls.key: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.certificate).data "tls.key" }}
+{{ else }}
   tls.crt: {{ $ca.Cert | b64enc }}
   tls.key: {{ $ca.Key  | b64enc }}
+{{ end }}
 ...
 ---
 apiVersion: v1
@@ -46,6 +57,10 @@ metadata:
     "helm.sh/hook": pre-install
 type: Opaque
 data:
-  PGBACKREST_REPO1_S3_REGION: dXMtZWFzdC0y # us-east-2
+{{- if .Release.IsUpgrade }}
+  PGBACKREST_REPO1_S3_REGION: {{ index (lookup "v1" "Secret" .Release.Namespace .Values.secretNames.pgbackrest).data "PGBACKREST_REPO1_S3_REGION" }}
+{{ else }}
+  PGBACKREST_REPO1_S3_REGION: {{ randAlphaNum 16 | b64enc }}
+{{ end }}
 ...
 {{- end }}


### PR DESCRIPTION
This should simplify logic regarding handling credentials and potentially make "unsafe" mode obsolete.