### PR TITLE
fix(charts): add selector on timescaledb-single service

### DIFF
--- a/charts/timescaledb-single/Chart.yaml
+++ b/charts/timescaledb-single/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 name: timescaledb-single
 description: 'TimescaleDB HA Deployment.'
-version: 0.10.0
+version: 0.10.1
 # appVersion specifies the version of the software, which can vary wildly,
 # e.g. TimescaleDB 1.4.1 on PostgreSQL 11 or TimescaleDB 1.5.0 on PostgreSQL 12.
 # https://github.com/helm/helm/blob/master/docs/charts.md#the-appversion-field

--- a/charts/timescaledb-single/templates/svc-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/svc-timescaledb.yaml
@@ -23,6 +23,10 @@ metadata:
 {{ .Values.service.primary.annotations | toYaml | indent 4 }}
 {{- end }}
 spec:
+  selector:
+    app: {{ template "timescaledb.fullname" . }}
+    cluster-name: {{ template "clusterName" . }}
+    role: master
 {{- if .Values.loadBalancer.enabled }}
   type: LoadBalancer
 {{- else }}


### PR DESCRIPTION
Hello,

I stumbled on the fact that the template `svc-timescaledb.yaml` in the chart `timescaledb-single` does not define any selector, contrarily to `svc-timescaledb-replica.yaml` which connects to the replica.

This PR proposes to add a selector to the service, connecting to the master node.
I also bumped the chart version, let me know if you prefer bumping it during the release process.

Let me know what you think about it! :)