### PR TITLE
charts/timescaledb-single: comment out key, secret

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -54,8 +54,8 @@ secrets:
   # This secret should contain environment variables that influence pgBackRest.
   pgbackrest:
     PGBACKREST_REPO1_S3_REGION: ""
-    PGBACKREST_REPO1_S3_KEY: ""
-    PGBACKREST_REPO1_S3_KEY_SECRET: ""
+    # PGBACKREST_REPO1_S3_KEY: ""
+    # PGBACKREST_REPO1_S3_KEY_SECRET: ""
     PGBACKREST_REPO1_S3_BUCKET: ""
     PGBACKREST_REPO1_S3_ENDPOINT: "s3.amazonaws.com"
   


### PR DESCRIPTION
These default variables must be removed if you want to use instance based authentication with eg. kube2iam. If they are not removed, they will be set as empty environment variables and pgbackrest will fail with: `ERROR: [032]: environment variable 'repo1-s3-key' must have a value` because `PGBACKREST_REPO1_S3_KEY_TYPE: auto` will be ignored.

Full error message with the default variables:

```bash
ERROR: [032]: environment variable 'repo1-s3-key' must have a value
2022-01-17 11:10:53,212 - ERROR - history - Command '['pgbackrest', '--stanza=poddb', 'info', '--output=json']' returned non-zero exit status 32.
Traceback (most recent call last):
File "/scripts/pgbackrest-rest.py", line 362, in history_refresher
pgbackrest_out = check_output(['pgbackrest', '--stanza={0}'.format(stanza), 'info', '--output=json']).decode("utf-8")
File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
File "/usr/lib/python3.9/subprocess.py", line 528, in run
raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['pgbackrest', '--stanza=poddb', 'info', '--output=json']' returned non-zero exit status 32.
```

My custom values.yaml:

```yaml
secrets:
  pgbackrest:
    PGBACKREST_REPO1_S3_KEY_TYPE: auto
    PGBACKREST_REPO1_S3_BUCKET: some-s3-bucket
    PGBACKREST_REPO1_S3_ENDPOINT: s3.eu-central-1.amazonaws.com
    PGBACKREST_REPO1_S3_REGION: eu-central-1

podAnnotations:
    iam.amazonaws.com/role: my-iam-role-arn-for-kube2iam

```

When I comment out the default values for `PGBACKREST_REPO1_S3_KEY` and `PGBACKREST_REPO1_S3_KEY_SECRET` my config works. The iam role 

If there is a more clever way to fix it, please say so.

Best regards
Lars
