### PR TITLE
fix(chart): use *SecretName in statefulset when defined

### DIFF
--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -103,13 +103,13 @@ ${HOME}/.pgbackrest_environment
 {{- end -}}
 
 {{- define "secrets_credentials" -}}
-{{ printf "%s-credentials" (include "clusterName" .) }}
+{{ .Values.secrets.credentialsSecretName | default (printf "%s-credentials" (include "clusterName" .)) }}
 {{- end -}}
 
 {{- define "secrets_certificate" -}}
-{{ printf "%s-certificate" (include "clusterName" .) }}
+{{ .Values.secrets.certificateSecretName | default (printf "%s-certificate" (include "clusterName" .)) }}
 {{- end -}}
 
 {{- define "secrets_pgbackrest" -}}
-{{ printf "%s-pgbackrest" (include "clusterName" .) }}
+{{ .Values.secrets.pgBackRestSecretName | default (printf "%s-pgbackrest" (include "clusterName" .)) }}
 {{- end -}}


### PR DESCRIPTION
Hello,

It seems that when a user manages their own secrets through the values `secrets.credentialsSecretName`, `secrets.certificateSecretName`, or `secrets.pgBackRestSecretName`, the mounted volumes still uses the pattern `${ClusterName}-${secretType}`.

In those cases, we would rather use the user-defined secrets.

Let me know what you think about it! 