### PR TITLE
feature: adds option to use persistent-volume as repo for pgbackrest

### DIFF
--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -115,5 +115,5 @@ ${HOME}/.pgbackrest_environment
 {{- end -}}
 
 {{- define "secrets_pgbackrest" -}}
-{{ printf "%s-pgbackrest" (include "clusterName" .) }}
+{{ .Values.secrets.pgbackrestSecretName | default (printf "%s-pgbackrest" (include "clusterName" .)) }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -66,6 +66,10 @@ ${HOME}/.pgbackrest_environment
 /etc/pgbackrest/bootstrap
 {{- end -}}
 
+{{- define "pgbackrest_backup_pvc" -}}
+{{ printf "%s-backup-volume" (include "clusterName" .) }}
+{{- end -}}
+
 {{- define "pgbackrest_repo1_path" -}}
 {{ printf "/%s/%s/" .Release.Namespace (include "clusterName" .) }}
 {{- end -}}

--- a/charts/timescaledb-single/templates/_helpers.tpl
+++ b/charts/timescaledb-single/templates/_helpers.tpl
@@ -66,6 +66,10 @@ ${HOME}/.pgbackrest_environment
 /etc/pgbackrest/bootstrap
 {{- end -}}
 
+{{- define "pgbackrest_repo1_path" -}}
+{{ printf "/%s/%s/" .Release.Namespace (include "clusterName" .) }}
+{{- end -}}
+
 {{- define "postgres.uid" -}}
 {{- default .Values.uid "1000" -}}
 {{- end -}}

--- a/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "timescaledb.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- $globalDefaults := dict "spool-path" (include "socket_directory" .) "compress-level" "3" "repo1-path" (printf "/%s/%s/" .Release.Namespace (include "clusterName" .)) }}
+{{- $globalDefaults := dict "spool-path" (include "socket_directory" .) "compress-level" "3" "repo1-path" (include "pgbackrest_repo1_path" .) }}
 {{- $globals := merge .Values.backup.pgBackRest $globalDefaults }}
 {{- $push := index .Values.backup "pgBackRest:archive-push" | default dict }}
 {{- $get := index .Values.backup "pgBackRest:archive-get" | default dict }}

--- a/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/configmap-pgbackrest.yaml
@@ -11,7 +11,7 @@ metadata:
     chart: {{ template "timescaledb.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- $globalDefaults := dict "spool-path" (include "socket_directory" .) "compress-level" "3" "repo1-path" (include "pgbackrest_repo1_path" .) }}
+{{- $globalDefaults := dict "spool-path" (include "socket_directory" .) "compress-level" "3" }}
 {{- $globals := merge .Values.backup.pgBackRest $globalDefaults }}
 {{- $push := index .Values.backup "pgBackRest:archive-push" | default dict }}
 {{- $get := index .Values.backup "pgBackRest:archive-get" | default dict }}

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -208,6 +208,7 @@ data:
         # we want to override the environment with the environment
         # shellcheck disable=SC2046
         export $(env -i envdir {{ template "pgbackrest_bootstrap_environment_dir" . | quote }} env) > /dev/null
+        # export PGBACKREST_REPO1_PATH={{ index .Values.bootstrapFromBackup "repo1-path" | default ( include "pgbackrest_repo1_path" .) | quote }}
         export PGBACKREST_REPO1_PATH={{ index .Values.bootstrapFromBackup "repo1-path" | quote }}
 
         if [ -z "${PGBACKREST_REPO1_PATH}" ]; then

--- a/charts/timescaledb-single/templates/configmap-scripts.yaml
+++ b/charts/timescaledb-single/templates/configmap-scripts.yaml
@@ -208,7 +208,6 @@ data:
         # we want to override the environment with the environment
         # shellcheck disable=SC2046
         export $(env -i envdir {{ template "pgbackrest_bootstrap_environment_dir" . | quote }} env) > /dev/null
-        # export PGBACKREST_REPO1_PATH={{ index .Values.bootstrapFromBackup "repo1-path" | default ( include "pgbackrest_repo1_path" .) | quote }}
         export PGBACKREST_REPO1_PATH={{ index .Values.bootstrapFromBackup "repo1-path" | quote }}
 
         if [ -z "${PGBACKREST_REPO1_PATH}" ]; then

--- a/charts/timescaledb-single/templates/networkpolicy.yaml
+++ b/charts/timescaledb-single/templates/networkpolicy.yaml
@@ -28,7 +28,7 @@ spec:
       - port: 8081
         protocol: TCP
     {{ if .Values.prometheus.enabled }}
-    # Prom server for scraping exporter
+    # Prometheus server for scraping exporter
     - from:
       - podSelector:
           matchLabels:

--- a/charts/timescaledb-single/templates/pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pgbackrest.yaml
@@ -24,7 +24,7 @@ spec:
 ...
 {{- range .Values.backup.jobs }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "timescaledb.fullname" $ }}-{{ .name }}

--- a/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
@@ -21,11 +21,11 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.persistentVolumes.backup.size }}"
-{{- if .Values.persistentVolumes.backup.storageClassName }}
-{{- if (eq "-" .Values.persistentVolumes.backup.storageClassName) }}
+{{- if .Values.persistentVolumes.backup.storageClass }}
+{{- if (eq "-" .Values.persistentVolumes.backup.storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .Values.persistentVolumes.backup.storageClassName }}"
+  storageClassName: "{{ .Values.persistentVolumes.backup.storageClass }}"
 {{- end }}
 {{- end }}
 {{ end }}

--- a/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: backup-volume
+  name: {{ template "pgbackrest_backup_pvc" . }}
   {{- if .Values.persistentVolumes.backup.annotations }}
   annotations:
 {{ toYaml .Values.persistentVolumes.backup.annotations | indent 4 }}
@@ -14,7 +14,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     cluster-name: {{ template "clusterName" . }}
-    purpose: backup-directory
+    purpose: backup-storage
 spec:
   accessModes:
 {{ toYaml .Values.persistentVolumes.backup.accessModes | indent 4 }}

--- a/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
@@ -1,12 +1,12 @@
-# This PersistentVolumeClaim is only created if enabled.
 {{ if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
 ---
+# This PersistentVolumeClaim is only created if enabled.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: backup-volume
-  annotations:
   {{- if .Values.persistentVolumes.backup.annotations }}
+  annotations:
 {{ toYaml .Values.persistentVolumes.backup.annotations | indent 4 }}
   {{- end }}
   labels:

--- a/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/pvc-pgbackrest.yaml
@@ -1,0 +1,31 @@
+# This PersistentVolumeClaim is only created if enabled.
+{{ if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backup-volume
+  annotations:
+  {{- if .Values.persistentVolumes.backup.annotations }}
+{{ toYaml .Values.persistentVolumes.backup.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "timescaledb.fullname" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster-name: {{ template "clusterName" . }}
+    purpose: backup-directory
+spec:
+  accessModes:
+{{ toYaml .Values.persistentVolumes.backup.accessModes | indent 4 }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistentVolumes.backup.size }}"
+{{- if .Values.persistentVolumes.backup.storageClassName }}
+{{- if (eq "-" .Values.persistentVolumes.backup.storageClassName) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistentVolumes.backup.storageClassName }}"
+{{- end }}
+{{- end }}
+{{ end }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -1,6 +1,7 @@
+{{- if and (eq .Values.secrets.pgbackrestSecretName "") .Values.secrets.pgbackrest }}
+---
 # This file and its contents are licensed under the Apache License 2.0.
 # Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
-{{- if eq .Values.secrets.pgbackrestSecretName "" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -533,7 +533,7 @@ spec:
       {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
       - name: backup-volume
         persistentVolumeClaim:
-          claimName: backup-volume
+          claimName: {{ template "pgbackrest_backup_pvc" . }}
       {{- end }}
       - name: certificate
         secret:

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -564,11 +564,11 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.persistentVolumes.data.size }}"
-      {{- if .Values.persistentVolumes.data.storageClassName }}
-      {{- if (eq "-" .Values.persistentVolumes.data.storageClassName) }}
+      {{- if .Values.persistentVolumes.data.storageClass }}
+      {{- if (eq "-" .Values.persistentVolumes.data.storageClass) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.persistentVolumes.data.storageClassName }}"
+        storageClassName: "{{ .Values.persistentVolumes.data.storageClass }}"
       {{- end }}
       {{- end }}
   {{- end }}
@@ -591,11 +591,11 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.persistentVolumes.wal.size }}"
-      {{- if .Values.persistentVolumes.wal.storageClassName }}
-      {{- if (eq "-" .Values.persistentVolumes.wal.storageClassName) }}
+      {{- if .Values.persistentVolumes.wal.storageClass }}
+      {{- if (eq "-" .Values.persistentVolumes.wal.storageClass) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.persistentVolumes.wal.storageClassName }}"
+        storageClassName: "{{ .Values.persistentVolumes.wal.storageClass }}"
       {{- end }}
       {{- end }}
   {{- end }}
@@ -617,5 +617,5 @@ spec:
         resources:
           requests:
             storage: "{{ $volume.size }}"
-        storageClassName: {{ $volume.storageClassName | default "" }}
+        storageClassName: {{ $volume.storageClass | default "" }}
 {{- end }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -430,7 +430,7 @@ spec:
               optional: false
           - secretRef:
               name: {{ template "secrets_pgbackrest" . }}
-              optional: false
+              optional: true
           {{- if or .Values.envFrom .Values.backup.envFrom -}}
           {{- .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 10 -}}
           {{- end }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -237,6 +237,10 @@ spec:
             value: {{ template "clusterName" . }}
           - name: PGBACKREST_CONFIG
             value: /etc/pgbackrest/pgbackrest.conf
+          {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+          - name: PGBACKREST_REPO1_PATH
+            value: {{ template "pgbackrest_repo1_path" }}
+          {{- end }}
           # PGDATA and PGHOST are not required to let Patroni/PostgreSQL run correctly,
           # but for interactive sessions, callbacks and PostgreSQL tools they should be correct.
           - name: PGDATA
@@ -295,7 +299,6 @@ spec:
         {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
         - name: backup-volume
           mountPath: {{ (include "pgbackrest_repo1_path" $) }}
-          # mountPath: {{ .Values.persistentVolumes.backup.mountPath | quote }}
           subPath: {{ .Values.persistentVolumes.backup.subPath | quote }}
         {{- end }}
         {{- if .Values.sharedMemory.useMount }}
@@ -423,6 +426,10 @@ spec:
             value: poddb
           - name: PGBACKREST_CONFIG
             value: /etc/pgbackrest/pgbackrest.conf
+          {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+          - name: PGBACKREST_REPO1_PATH
+            value: {{ template "pgbackrest_repo1_path" }}
+          {{- end }}
           {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 10 }}{{- end }}
         envFrom:
           - secretRef:

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -239,7 +239,7 @@ spec:
             value: /etc/pgbackrest/pgbackrest.conf
           {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
           - name: PGBACKREST_REPO1_PATH
-            value: {{ template "pgbackrest_repo1_path" }}
+            value: {{ template "pgbackrest_repo1_path" . }}
           {{- end }}
           # PGDATA and PGHOST are not required to let Patroni/PostgreSQL run correctly,
           # but for interactive sessions, callbacks and PostgreSQL tools they should be correct.
@@ -428,7 +428,7 @@ spec:
             value: /etc/pgbackrest/pgbackrest.conf
           {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
           - name: PGBACKREST_REPO1_PATH
-            value: {{ template "pgbackrest_repo1_path" }}
+            value: {{ template "pgbackrest_repo1_path" . }}
           {{- end }}
           {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 10 }}{{- end }}
         envFrom:

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -195,79 +195,79 @@ spec:
 
             exec patroni /etc/timescaledb/patroni.yaml
         env:
-        # We use mixed case environment variables for Patroni User management,
-        # as the variable themselves are documented to be PATRONI_<username>_OPTIONS.
-        # Where possible, we want to have lowercase usernames in PostgreSQL as more complex postgres usernames
-        # requiring quoting to be done in certain contexts, which many tools do not do correctly, or even at all.
-        # https://patroni.readthedocs.io/en/latest/ENVIRONMENT.html#bootstrap-configuration
-        - name: PATRONI_admin_OPTIONS
-          value: createrole,createdb
-        - name: PATRONI_REPLICATION_USERNAME
-          value: standby
-        # To specify the PostgreSQL and Rest API connect addresses we need
-        # the PATRONI_KUBERNETES_POD_IP to be available as a bash variable, so we can compose an
-        # IP:PORT address later on
-        - name: PATRONI_KUBERNETES_POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        - name: PATRONI_POSTGRESQL_CONNECT_ADDRESS
-          value: "$(PATRONI_KUBERNETES_POD_IP):5432"
-        - name: PATRONI_RESTAPI_CONNECT_ADDRESS
-          value: "$(PATRONI_KUBERNETES_POD_IP):8008"
-        - name: PATRONI_KUBERNETES_PORTS
-          {{- if .Values.pgBouncer.enabled }}
-          value: '[{"name": "postgresql", "port": 5432}, {"name": "pgbouncer", "port": 6432}]'
-          {{- else }}
-          value: '[{"name": "postgresql", "port": 5432}]'
+          # We use mixed case environment variables for Patroni User management,
+          # as the variable themselves are documented to be PATRONI_<username>_OPTIONS.
+          # Where possible, we want to have lowercase usernames in PostgreSQL as more complex postgres usernames
+          # requiring quoting to be done in certain contexts, which many tools do not do correctly, or even at all.
+          # https://patroni.readthedocs.io/en/latest/ENVIRONMENT.html#bootstrap-configuration
+          - name: PATRONI_admin_OPTIONS
+            value: createrole,createdb
+          - name: PATRONI_REPLICATION_USERNAME
+            value: standby
+          # To specify the PostgreSQL and Rest API connect addresses we need
+          # the PATRONI_KUBERNETES_POD_IP to be available as a bash variable, so we can compose an
+          # IP:PORT address later on
+          - name: PATRONI_KUBERNETES_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: PATRONI_POSTGRESQL_CONNECT_ADDRESS
+            value: "$(PATRONI_KUBERNETES_POD_IP):5432"
+          - name: PATRONI_RESTAPI_CONNECT_ADDRESS
+            value: "$(PATRONI_KUBERNETES_POD_IP):8008"
+          - name: PATRONI_KUBERNETES_PORTS
+            {{- if .Values.pgBouncer.enabled }}
+            value: '[{"name": "postgresql", "port": 5432}, {"name": "pgbouncer", "port": 6432}]'
+            {{- else }}
+            value: '[{"name": "postgresql", "port": 5432}]'
+            {{- end }}
+          - name: PATRONI_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: PATRONI_POSTGRESQL_DATA_DIR
+            value: {{ include "data_directory" . | quote }}
+          - name: PATRONI_KUBERNETES_NAMESPACE
+            value: {{ $.Release.Namespace }}
+          - name: PATRONI_KUBERNETES_LABELS
+            value: {{ printf "{app: %s, cluster-name: %s, release: %s}" (include "timescaledb.fullname" .) (include "clusterName" .) .Release.Name  | quote }}
+          - name: PATRONI_SCOPE
+            value: {{ template "clusterName" . }}
+          - name: PGBACKREST_CONFIG
+            value: /etc/pgbackrest/pgbackrest.conf
+          # PGDATA and PGHOST are not required to let Patroni/PostgreSQL run correctly,
+          # but for interactive sessions, callbacks and PostgreSQL tools they should be correct.
+          - name: PGDATA
+            value: "$(PATRONI_POSTGRESQL_DATA_DIR)"
+          - name: PGHOST
+            value: "{{ template "socket_directory" . }}"
+          - name: BOOTSTRAP_FROM_BACKUP
+            value: {{ .Values.bootstrapFromBackup.enabled | int | quote }}
+          {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 10 }}{{- end }}
+            # pgBackRest is also called using the archive_command if the backup is enabled.
+            # this script will also need access to the environment variables specified for
+            # the backup. This can be removed once we do not directly invoke pgBackRest
+            # from inside the TimescaleDB container anymore
+          {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 10 }}{{- end }}
+          {{- if .Values.version }}
+          - name: PATH
+            value: /usr/lib/postgresql/{{ .Values.version }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
           {{- end }}
-        - name: PATRONI_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: PATRONI_POSTGRESQL_DATA_DIR
-          value: {{ include "data_directory" . | quote }}
-        - name: PATRONI_KUBERNETES_NAMESPACE
-          value: {{ $.Release.Namespace }}
-        - name: PATRONI_KUBERNETES_LABELS
-          value: {{ printf "{app: %s, cluster-name: %s, release: %s}" (include "timescaledb.fullname" .) (include "clusterName" .) .Release.Name  | quote }}
-        - name: PATRONI_SCOPE
-          value: {{ template "clusterName" . }}
-        - name: PGBACKREST_CONFIG
-          value: /etc/pgbackrest/pgbackrest.conf
-        # PGDATA and PGHOST are not required to let Patroni/PostgreSQL run correctly,
-        # but for interactive sessions, callbacks and PostgreSQL tools they should be correct.
-        - name: PGDATA
-          value: "$(PATRONI_POSTGRESQL_DATA_DIR)"
-        - name: PGHOST
-          value: "{{ template "socket_directory" . }}"
-        - name: BOOTSTRAP_FROM_BACKUP
-          value: {{ .Values.bootstrapFromBackup.enabled | int | quote }}
-        {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 8 }}{{- end }}
-          # pgBackRest is also called using the archive_command if the backup is enabled.
-          # this script will also need access to the environment variables specified for
-          # the backup. This can be removed once we do not directly invoke pgBackRest
-          # from inside the TimescaleDB container anymore
-        {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 8 }}{{- end }}
-        {{- if .Values.version }}
-        - name: PATH
-          value: /usr/lib/postgresql/{{ .Values.version }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        {{- end }}
         envFrom:
-        - secretRef:
-            name: {{ template "secrets_credentials" . }}
-            optional: false
-        - secretRef:
-            name: {{ template "secrets_pgbackrest" . }}
-            optional: true
-        {{- if or .Values.envFrom .Values.backup.envFrom -}}
-        {{- .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 8 -}}
-        {{- end }}
+          - secretRef:
+              name: {{ template "secrets_credentials" . }}
+              optional: false
+          - secretRef:
+              name: {{ template "secrets_pgbackrest" . }}
+              optional: true
+          {{- if or .Values.envFrom .Values.backup.envFrom -}}
+          {{- .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 10 -}}
+          {{- end }}
         ports:
-        - containerPort: 8008
-          name: patroni
-        - containerPort: 5432
-          name: postgresql
+          - containerPort: 8008
+            name: patroni
+          - containerPort: 5432
+            name: postgresql
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           exec:
@@ -289,6 +289,12 @@ spec:
         - name: wal-volume
           mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
           subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
+        {{- end }}
+        {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+        - name: backup-volume
+          mountPath: {{ (include "pgbackrest_repo1_path" $) }}
+          # mountPath: {{ .Values.persistentVolumes.backup.mountPath | quote }}
+          subPath: {{ .Values.persistentVolumes.backup.subPath | quote }}
         {{- end }}
         {{- if .Values.sharedMemory.useMount }}
         - name: shared-memory
@@ -382,27 +388,33 @@ spec:
         - containerPort: 8081
           name: pgbackrest
         volumeMounts:
-        - name: socket-directory
-          mountPath: {{ template "socket_directory" . }}
-          readOnly: true
-        - name: storage-volume
-          mountPath: {{ .Values.persistentVolumes.data.mountPath | quote }}
-          subPath: {{ .Values.persistentVolumes.data.subPath | quote }}
-        {{- if .Values.persistentVolumes.wal.enabled }}
-        - name: wal-volume
-          mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
-          subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
-        {{- end }}
+          - name: socket-directory
+            mountPath: {{ template "socket_directory" . }}
+            readOnly: true
+          - name: storage-volume
+            mountPath: {{ .Values.persistentVolumes.data.mountPath | quote }}
+            subPath: {{ .Values.persistentVolumes.data.subPath | quote }}
+          {{- if .Values.persistentVolumes.wal.enabled }}
+          - name: wal-volume
+            mountPath: {{ .Values.persistentVolumes.wal.mountPath | quote }}
+            subPath: {{ .Values.persistentVolumes.wal.subPath | quote }}
+          {{- end }}
+          {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+          - name: backup-volume
+            mountPath: {{ (include "pgbackrest_repo1_path" $) }}
+            # mountPath: {{ .Values.persistentVolumes.backup.mountPath | quote }}
+            subPath: {{ .Values.persistentVolumes.backup.subPath | quote }}
+          {{- end }}
 {{- range $tablespaceName := ( .Values.persistentVolumes.tablespaces | default dict | keys ) }}
-        - name: {{ $tablespaceName }}
-          mountPath: {{ printf "%s/%s" (include "tablespaces_dir" $) $tablespaceName }}
+          - name: {{ $tablespaceName }}
+            mountPath: {{ printf "%s/%s" (include "tablespaces_dir" $) $tablespaceName }}
 {{- end }}
-        - mountPath: /etc/pgbackrest
-          name: pgbackrest
-          readOnly: true
-        - mountPath: {{ template "scripts_dir" . }}
-          name: timescaledb-scripts
-          readOnly: true
+          - name: pgbackrest
+            mountPath: /etc/pgbackrest
+            readOnly: true
+          - name: timescaledb-scripts
+            mountPath: {{ template "scripts_dir" . }}
+            readOnly: true
         env:
           - name: PGHOST
             value: {{ template "socket_directory" . }}
@@ -412,15 +424,15 @@ spec:
             value: /etc/pgbackrest/pgbackrest.conf
           {{- if .Values.backup.env }}{{ .Values.backup.env | default list | toYaml | nindent 10 }}{{- end }}
         envFrom:
-        - secretRef:
-            name: {{ template "secrets_credentials" . }}
-            optional: false
-        - secretRef:
-            name: {{ template "secrets_pgbackrest" . }}
-            optional: false
-        {{- if or .Values.envFrom .Values.backup.envFrom -}}
-        {{- .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 8 -}}
-        {{- end }}
+          - secretRef:
+              name: {{ template "secrets_credentials" . }}
+              optional: false
+          - secretRef:
+              name: {{ template "secrets_pgbackrest" . }}
+              optional: false
+          {{- if or .Values.envFrom .Values.backup.envFrom -}}
+          {{- .Values.backup.envFrom | default list | concat (.Values.envFrom | default list) | toYaml | nindent 10 -}}
+          {{- end }}
 {{ end }}
 
 {{- if .Values.prometheus.enabled }}
@@ -510,6 +522,11 @@ spec:
           name: {{ template "timescaledb.fullname" . }}-pgbackrest
           defaultMode: 416 # 0640 permissions
           optional: true
+      {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
+      - name: backup-volume
+        persistentVolumeClaim:
+          claimName: backup-volume
+      {{- end }}
       - name: certificate
         secret:
           secretName:  {{ template "secrets_certificate" . }}
@@ -545,11 +562,11 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.persistentVolumes.data.size }}"
-      {{- if .Values.persistentVolumes.data.storageClass }}
-      {{- if (eq "-" .Values.persistentVolumes.data.storageClass) }}
+      {{- if .Values.persistentVolumes.data.storageClassName }}
+      {{- if (eq "-" .Values.persistentVolumes.data.storageClassName) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.persistentVolumes.data.storageClass }}"
+        storageClassName: "{{ .Values.persistentVolumes.data.storageClassName }}"
       {{- end }}
       {{- end }}
   {{- end }}
@@ -572,11 +589,11 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.persistentVolumes.wal.size }}"
-      {{- if .Values.persistentVolumes.wal.storageClass }}
-      {{- if (eq "-" .Values.persistentVolumes.wal.storageClass) }}
+      {{- if .Values.persistentVolumes.wal.storageClassName }}
+      {{- if (eq "-" .Values.persistentVolumes.wal.storageClassName) }}
         storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.persistentVolumes.wal.storageClass }}"
+        storageClassName: "{{ .Values.persistentVolumes.wal.storageClassName }}"
       {{- end }}
       {{- end }}
   {{- end }}
@@ -598,5 +615,5 @@ spec:
         resources:
           requests:
             storage: "{{ $volume.size }}"
-        storageClassName: {{ $volume.storageClass | default "" }}
+        storageClassName: {{ $volume.storageClassName | default "" }}
 {{- end }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -51,7 +51,7 @@ spec:
         - name: TSTUNE_FILE
           value: {{ template "tstune_config" . }}
         - name: POSTGRES_MAJOR_VERSION
-          value: {{ .Values.version | quote }}
+          value: {{ .Values.version | default 11 | quote }}
         - name: RESOURCES_WAL_VOLUME
           value: {{ if .Values.persistentVolumes.wal.enabled }}{{ .Values.persistentVolumes.wal.size }}{{ else }}"0"{{ end }}
         - name: RESOURCES_DATA_VOLUME

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -404,7 +404,6 @@ spec:
           {{- if and .Values.backup.enabled .Values.persistentVolumes.backup.enabled }}
           - name: backup-volume
             mountPath: {{ (include "pgbackrest_repo1_path" $) }}
-            # mountPath: {{ .Values.persistentVolumes.backup.mountPath | quote }}
             subPath: {{ .Values.persistentVolumes.backup.subPath | quote }}
           {{- end }}
 {{- range $tablespaceName := ( .Values.persistentVolumes.tablespaces | default dict | keys ) }}
@@ -548,8 +547,8 @@ spec:
   {{- if .Values.persistentVolumes.data.enabled }}
     - metadata:
         name: storage-volume
-        annotations:
         {{- if .Values.persistentVolumes.data.annotations }}
+        annotations:
 {{ toYaml .Values.persistentVolumes.data.annotations | indent 10 }}
         {{- end }}
         labels:
@@ -575,8 +574,8 @@ spec:
   {{- if .Values.persistentVolumes.wal.enabled }}
     - metadata:
         name: wal-volume
-        annotations:
         {{- if .Values.persistentVolumes.wal.annotations }}
+        annotations:
 {{ toYaml .Values.persistentVolumes.wal.annotations | indent 10 }}
         {{- end }}
         labels:
@@ -602,8 +601,10 @@ spec:
 {{- range $tablespaceName, $volume := ($.Values.persistentVolumes.tablespaces | default dict ) }}
     - metadata:
         name: {{ $tablespaceName }}
+        {{- if $volume.annotations }}
         annotations:
 {{ $volume.annotations | default dict | toYaml | indent 10 }}
+        {{- end }}
         labels:
           app: {{ template "timescaledb.fullname" $ }}
           release: {{ $.Release.Name }}

--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -50,6 +50,8 @@ spec:
         env:
         - name: TSTUNE_FILE
           value: {{ template "tstune_config" . }}
+        - name: POSTGRES_MAJOR_VERSION
+          value: {{ .Values.version | quote }}
         - name: RESOURCES_WAL_VOLUME
           value: {{ if .Values.persistentVolumes.wal.enabled }}{{ .Values.persistentVolumes.wal.size }}{{ else }}"0"{{ end }}
         - name: RESOURCES_DATA_VOLUME
@@ -93,7 +95,7 @@ spec:
               fi
 
               touch "${TSTUNE_FILE}"
-              timescaledb-tune -quiet -pg-version 11 -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" \
+              timescaledb-tune -quiet -pg-version ${POSTGRES_MAJOR_VERSION} -conf-path "${TSTUNE_FILE}" -cpus "${CPUS}" -memory "${MEMORY}MB" \
                 {{ range $key, $value := .Values.timescaledbTune.args | default dict }}{{ printf "--%s %s " $key (quote $value)}}{{ end }} -yes
 
               # If there is a dedicated WAL Volume, we want to set max_wal_size to 60% of that volume

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -107,7 +107,7 @@
         "size": {
           "type": "string"
         },
-        "storageClassName": {
+        "storageClass": {
           "type": [
             "string",
             "null"

--- a/charts/timescaledb-single/values.schema.json
+++ b/charts/timescaledb-single/values.schema.json
@@ -107,7 +107,7 @@
         "size": {
           "type": "string"
         },
-        "storageClass": {
+        "storageClassName": {
           "type": [
             "string",
             "null"
@@ -542,6 +542,9 @@
           "type": "object"
         },
         "wal": {
+          "$ref": "#/definitions/volume"
+        },
+        "backup": {
           "$ref": "#/definitions/volume"
         }
       },

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -614,7 +614,7 @@ definitions:
         type:
         - string
         - "null"
-      storageClassName:
+      storageClass:
         type:
         - string
         - "null"

--- a/charts/timescaledb-single/values.schema.yaml
+++ b/charts/timescaledb-single/values.schema.yaml
@@ -117,6 +117,8 @@ properties:
         type: object
         additionalProperties:
           "$ref": "#/definitions/volume"
+      backup:
+        "$ref": "#/definitions/volume"
   readinessProbe:
     type: object
     additionalProperties: false
@@ -612,7 +614,7 @@ definitions:
         type:
         - string
         - "null"
-      storageClass:
+      storageClassName:
         type:
         - string
         - "null"

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -403,14 +403,16 @@ persistentVolumes:
     # example2:
     #   size: 5Gi
     #   storageClass: gp2
+  # If you want to use [repo-type](https://pgbackrest.org/configuration.html#section-repository/option-repo-type) `posix` with pgbackrest
+  # enable this persistentVolume and apply a storageClass that supports `ReadWriteMany` (e.g. NFS see https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
+  # Also you need to adjust `Values.backup.pgbackrest` to your needs (i.e. at least set the repo-type).
+  # It is recommended to remove all S3 related environment variables, values from config maps and secrets.
+  # `mountPath` and `subPath` are not used for this volume. The value for `mountPath` is generated and provided as template (`pgbackrest_repo1_path`)
+  # used for volume mounts and the `PGBACKREST_REPO1_PATH` environment variable (except when bootstraping from backup)
   backup:
     enabled: false
     size: 10Gi
-    subPath: ""
     # storageClass: "-"
-    # this is the default repo path 
-    # https://pgbackrest.org/configuration.html#section-repository/option-repo-path
-    mountPath: "/var/lib/pgbackrest"
     annotations: {}
     accessModes:
       - ReadWriteMany

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -14,14 +14,14 @@ clusterName:
 
 # The major PostgreSQL version to use, defaults to the default version of the Docker image
 # However, in pg_upgrade scenarios, you may need to specify an explicit version
-version:
+version: 14
 
 image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg13.4-ts2.4.2-p0
-  pullPolicy: Always
+  tag: pg14.1-ts2.5.1-oss-p2
+  pullPolicy: IfNotPresent
 
 # By default those secrets are randomly generated.
 # To prevent misconfiguration, modifications from helm upgrade won't be applied to those secrets.
@@ -53,11 +53,6 @@ secrets:
 
   # This secret should contain environment variables that influence pgBackRest.
   pgbackrest:
-    PGBACKREST_REPO1_S3_REGION: ""
-    PGBACKREST_REPO1_S3_KEY: ""
-    PGBACKREST_REPO1_S3_KEY_SECRET: ""
-    PGBACKREST_REPO1_S3_BUCKET: ""
-    PGBACKREST_REPO1_S3_ENDPOINT: "s3.amazonaws.com"
   
   # Selector used to provision your own Secret containing pgbackrest configuration details
   # This is mutually exclusive with `pgbackrest` option and takes precedence over it.
@@ -65,7 +60,7 @@ secrets:
   pgbackrestSecretName: ""
 
 backup:
-  enabled: false
+  enabled: true
   pgBackRest:
     # https://pgbackrest.org/configuration.html
     # Although not impossible, care should be taken not to include secrets
@@ -73,12 +68,6 @@ backup:
     compress-type: lz4
     process-max: 4
     start-fast: "y"
-    repo1-retention-diff: 2
-    repo1-retention-full: 2
-    repo1-type: s3
-    repo1-cipher-type: "none"
-    repo1-s3-region: us-east-2
-    repo1-s3-endpoint: s3.amazonaws.com
 
   # Overriding the archive-push/archive-get sections is most useful in
   # very high througput situations. Look at values/high_throuhgput_example.yaml for more details
@@ -104,13 +93,14 @@ backup:
   # Although not impossible, care should be taken not to include secrets
   # in these parameters. Use Kubernetes Secrets to specify S3 Keys, Secrets etc.
   env:
-  # - name: PGBACKREST_REPO1_S3_BUCKET
-  #   value: my_example_s3_bucket_for_backups
-  # - name: PGBACKREST_REPO1_S3_KEY_SECRET
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: pgbackrest-dev-secrets
-  #       key: repo1-s3-key-secret
+    - name: PGBACKREST_REPO1_RETENTION_DIFF
+      value: "2"
+    - name: PGBACKREST_REPO1_RETENTION_FULL_TYPE
+      value: time
+    - name: PGBACKREST_REPO1_RETENTION_FULL
+      value: "30"
+    # - name: PGBACKREST_REPO1_PATH
+    #   value: /backup/db/backrest # default is `/var/lib/pgbackrest`
 
 # When creating a *new* deployment, the default is to initialize (using initdb) the database.
 # If however, you want to initialize the database using an existing backup, you can do so by
@@ -322,7 +312,7 @@ service:
 loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service
   # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
-  enabled: true
+  enabled: false
   port: 5432
   # Read more about the AWS annotations here:
   # https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws
@@ -368,7 +358,7 @@ persistentVolumes:
   # https://www.postgresql.org/docs/current/creating-cluster.html#CREATING-CLUSTER-MOUNT-POINTS
   data:
     enabled: true
-    size: 2Gi
+    size: 10Gi
     ## database data Persistent Volume Storage Class
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -376,7 +366,7 @@ persistentVolumes:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    # storageClass: "-"
+    storageClassName: managed-nfs-storage
     subPath: ""
     mountPath: "/var/lib/postgresql"
     annotations: {}
@@ -388,7 +378,7 @@ persistentVolumes:
     enabled: true
     size: 1Gi
     subPath: ""
-    storageClass:
+    storageClassName: managed-nfs-storage
     # When changing this mountPath ensure you also change the following key to reflect this:
     # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
@@ -399,10 +389,21 @@ persistentVolumes:
   # tablespaces:
     # example1:
     #   size: 5Gi
-    #   storageClass: gp2
+    #   storageClassName: managed-nfs-storage
     # example2:
     #   size: 5Gi
-    #   storageClass: gp2
+    #   storageClassName: managed-nfs-storage
+  backup:
+    enabled: true
+    size: 10Gi
+    subPath: ""
+    storageClassName: managed-nfs-storage
+    # this is the default repo path 
+    # https://pgbackrest.org/configuration.html#section-repository/option-repo-path
+    mountPath: "/var/lib/pgbackrest"
+    annotations: {}
+    accessModes:
+      - ReadWriteMany
 
 # EXPERIMENTAL, please do *not* enable on production environments
 # if enabled, fullWalPrevention will switch the default transaction mode from read write
@@ -418,15 +419,15 @@ fullWalPrevention:
     readWriteFreePercent: 8
     readWriteFreeMB: 128
 
-resources: {}
+resources:
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 2Gi
 
 sharedMemory:
   # By default Kubernetes only provides 64MB to /dev/shm
@@ -465,7 +466,7 @@ timescaledbTune:
 # enabling pgBouncer will run an extra container in every Pod, serving a pgBouncer
 # pass-through instance
 pgBouncer:
-  enabled: false
+  enabled: true
   port: 6432
   config:
   # DANGER: The below settings are considered to be safe to set, and we recommend

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -360,13 +360,13 @@ persistentVolumes:
     enabled: true
     size: 10Gi
     ## database data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
+    ## If defined, storageClass: <storageClass>
+    ## If set to "-", storageClass: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClass spec is
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClassName: managed-nfs-storage
+    storageClass: managed-nfs-storage
     subPath: ""
     mountPath: "/var/lib/postgresql"
     annotations: {}
@@ -378,7 +378,7 @@ persistentVolumes:
     enabled: true
     size: 1Gi
     subPath: ""
-    storageClassName: managed-nfs-storage
+    storageClass: managed-nfs-storage
     # When changing this mountPath ensure you also change the following key to reflect this:
     # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
@@ -389,15 +389,15 @@ persistentVolumes:
   # tablespaces:
     # example1:
     #   size: 5Gi
-    #   storageClassName: managed-nfs-storage
+    #   storageClass: managed-nfs-storage
     # example2:
     #   size: 5Gi
-    #   storageClassName: managed-nfs-storage
+    #   storageClass: managed-nfs-storage
   backup:
     enabled: true
     size: 10Gi
     subPath: ""
-    storageClassName: managed-nfs-storage
+    storageClass: managed-nfs-storage
     # this is the default repo path 
     # https://pgbackrest.org/configuration.html#section-repository/option-repo-path
     mountPath: "/var/lib/pgbackrest"

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -14,14 +14,14 @@ clusterName:
 
 # The major PostgreSQL version to use, defaults to the default version of the Docker image
 # However, in pg_upgrade scenarios, you may need to specify an explicit version
-version: 14
+version:
 
 image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.1-ts2.5.1-oss-p2
-  pullPolicy: IfNotPresent
+  tag: pg13.4-ts2.4.2-p0
+  pullPolicy: Always
 
 # By default those secrets are randomly generated.
 # To prevent misconfiguration, modifications from helm upgrade won't be applied to those secrets.
@@ -53,6 +53,11 @@ secrets:
 
   # This secret should contain environment variables that influence pgBackRest.
   pgbackrest:
+    PGBACKREST_REPO1_S3_REGION: ""
+    PGBACKREST_REPO1_S3_KEY: ""
+    PGBACKREST_REPO1_S3_KEY_SECRET: ""
+    PGBACKREST_REPO1_S3_BUCKET: ""
+    PGBACKREST_REPO1_S3_ENDPOINT: "s3.amazonaws.com"
   
   # Selector used to provision your own Secret containing pgbackrest configuration details
   # This is mutually exclusive with `pgbackrest` option and takes precedence over it.
@@ -60,7 +65,7 @@ secrets:
   pgbackrestSecretName: ""
 
 backup:
-  enabled: true
+  enabled: false
   pgBackRest:
     # https://pgbackrest.org/configuration.html
     # Although not impossible, care should be taken not to include secrets
@@ -68,6 +73,12 @@ backup:
     compress-type: lz4
     process-max: 4
     start-fast: "y"
+    repo1-retention-diff: 2
+    repo1-retention-full: 2
+    repo1-type: s3
+    repo1-cipher-type: "none"
+    repo1-s3-region: us-east-2
+    repo1-s3-endpoint: s3.amazonaws.com
 
   # Overriding the archive-push/archive-get sections is most useful in
   # very high througput situations. Look at values/high_throuhgput_example.yaml for more details
@@ -93,14 +104,13 @@ backup:
   # Although not impossible, care should be taken not to include secrets
   # in these parameters. Use Kubernetes Secrets to specify S3 Keys, Secrets etc.
   env:
-    - name: PGBACKREST_REPO1_RETENTION_DIFF
-      value: "2"
-    - name: PGBACKREST_REPO1_RETENTION_FULL_TYPE
-      value: time
-    - name: PGBACKREST_REPO1_RETENTION_FULL
-      value: "30"
-    # - name: PGBACKREST_REPO1_PATH
-    #   value: /backup/db/backrest # default is `/var/lib/pgbackrest`
+  # - name: PGBACKREST_REPO1_S3_BUCKET
+  #   value: my_example_s3_bucket_for_backups
+  # - name: PGBACKREST_REPO1_S3_KEY_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: pgbackrest-dev-secrets
+  #       key: repo1-s3-key-secret
 
 # When creating a *new* deployment, the default is to initialize (using initdb) the database.
 # If however, you want to initialize the database using an existing backup, you can do so by
@@ -312,7 +322,7 @@ service:
 loadBalancer:
   # If not enabled, we still expose the primary using a so called Headless Service
   # https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
-  enabled: false
+  enabled: true
   port: 5432
   # Read more about the AWS annotations here:
   # https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws
@@ -358,7 +368,7 @@ persistentVolumes:
   # https://www.postgresql.org/docs/current/creating-cluster.html#CREATING-CLUSTER-MOUNT-POINTS
   data:
     enabled: true
-    size: 10Gi
+    size: 2Gi
     ## database data Persistent Volume Storage Class
     ## If defined, storageClass: <storageClass>
     ## If set to "-", storageClass: "", which disables dynamic provisioning
@@ -366,7 +376,7 @@ persistentVolumes:
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    storageClass: managed-nfs-storage
+    # storageClass: "-"
     subPath: ""
     mountPath: "/var/lib/postgresql"
     annotations: {}
@@ -378,7 +388,7 @@ persistentVolumes:
     enabled: true
     size: 1Gi
     subPath: ""
-    storageClass: managed-nfs-storage
+    storageClass:
     # When changing this mountPath ensure you also change the following key to reflect this:
     # patroni.postgresql.basebackup.[].waldir
     mountPath: "/var/lib/postgresql/wal"
@@ -389,15 +399,15 @@ persistentVolumes:
   # tablespaces:
     # example1:
     #   size: 5Gi
-    #   storageClass: managed-nfs-storage
+    #   storageClass: gp2
     # example2:
     #   size: 5Gi
-    #   storageClass: managed-nfs-storage
+    #   storageClass: gp2
   backup:
-    enabled: true
+    enabled: false
     size: 10Gi
     subPath: ""
-    storageClass: managed-nfs-storage
+    # storageClass: "-"
     # this is the default repo path 
     # https://pgbackrest.org/configuration.html#section-repository/option-repo-path
     mountPath: "/var/lib/pgbackrest"
@@ -419,15 +429,15 @@ fullWalPrevention:
     readWriteFreePercent: 8
     readWriteFreeMB: 128
 
-resources:
+resources: {}
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 500m
-    memory: 2Gi
-  requests:
-    cpu: 500m
-    memory: 2Gi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 sharedMemory:
   # By default Kubernetes only provides 64MB to /dev/shm
@@ -466,7 +476,7 @@ timescaledbTune:
 # enabling pgBouncer will run an extra container in every Pod, serving a pgBouncer
 # pass-through instance
 pgBouncer:
-  enabled: true
+  enabled: false
   port: 6432
   config:
   # DANGER: The below settings are considered to be safe to set, and we recommend

--- a/charts/timescaledb-single/values/pgbackrest_backupvolume.example.yaml
+++ b/charts/timescaledb-single/values/pgbackrest_backupvolume.example.yaml
@@ -1,0 +1,35 @@
+# This file and its contents are licensed under the Apache License 2.0.
+# Please see the included NOTICE for copyright information and LICENSE for a copy of the license.
+
+version: 14
+
+image:
+  tag: pg14.1-ts2.5.1-oss-p2
+  pullPolicy: IfNotPresent
+
+secrets:
+  pgbackrest:
+    # deleting s3 props from default values (see https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key)
+    PGBACKREST_REPO1_S3_REGION: null
+    PGBACKREST_REPO1_S3_KEY: null
+    PGBACKREST_REPO1_S3_KEY_SECRET: null
+    PGBACKREST_REPO1_S3_BUCKET: null
+    PGBACKREST_REPO1_S3_ENDPOINT: null
+
+backup:
+  enabled: true
+  pgBackRest:
+    # https://pgbackrest.org/configuration.html
+    # Although not impossible, care should be taken not to include secrets
+    # in these parameters. Use Kubernetes Secrets to specify S3 Keys, Secrets etc.
+    # deleting s3 props from default values (see https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key)
+    repo1-s3-region: null
+    repo1-s3-endpoint: null
+    # since the default repo-type is `posix` we could also delete this key - but being explicit about this also has advantages
+    repo1-type: posix
+
+persistentVolumes:
+  backup:
+    enabled: true
+    # creating that storageClass is not scope of this chart
+    storageClass: nfs


### PR DESCRIPTION
Adds an optional persistent volume claim for a backup-volume.
When enabled, this volume is bound to every Pod in the StatefulSet (s3 buckets are also equally available from all pods) and environment variables to configure pgbackrest accordingly are generated and injected.

I've provided a sample configuration in `charts/timescaledb-single/values/pgbackrest_backupvolume.example.yaml`