### PR TITLE
Fixed yaml parse when additional credentials are provided for patroni

### DIFF
--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -19,7 +19,7 @@ stringData:
   {{- range $k, $v := .Values.secrets.credentials }}
     {{- $passwords := list "PATRONI_SUPERUSER_PASSWORD" "PATRONI_REPLICATION_PASSWORD" "PATRONI_admin_PASSWORD" }}
     {{- if not (has $k $passwords) }}
-      {{- $k | indent 2 }}: {{ $v }}
+      {{- $k | nindent 2 }}: {{ $v }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #323

When providing additional credentials for patroni invalid yaml will be generation during helm template processing.

values.yaml
```yaml
secrets:
  credentials:
    PATRONI_test_PASSWORD: "test"
    PATRONI_test2_PASSWORD: "test2"
```

secret-patroni without fix:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: "RELEASE-NAME-credentials"
  labels:
    app: RELEASE-NAME-timescaledb
    cluster-name: RELEASE-NAME
type: Opaque
stringData:
  PATRONI_SUPERUSER_PASSWORD: "Rlmv6dfg51cIPepM"
  PATRONI_REPLICATION_PASSWORD: "8PeHhYkViGbJmysg"
  PATRONI_admin_PASSWORD: "B6oaJhGNYp4mDTBA"  PATRONI_test2_PASSWORD: test2  PATRONI_test_PASSWORD: test
```

secret-patroni with fix:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: "RELEASE-NAME-credentials"
  labels:
    app: RELEASE-NAME-timescaledb
    cluster-name: RELEASE-NAME
type: Opaque
stringData:
  PATRONI_SUPERUSER_PASSWORD: "RcuwuNFYRmRFzndC"
  PATRONI_REPLICATION_PASSWORD: "CoBPAeD3eaIIYEFd"
  PATRONI_admin_PASSWORD: "swXzbwl5xNeDKALh"
  PATRONI_test2_PASSWORD: test2
  PATRONI_test_PASSWORD: test
```