### PR TITLE
charts/timescaledb-single: add imagePullSecrets

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -41,6 +41,10 @@ spec:
         runAsGroup: {{ template "postgres.uid" }}
         runAsNonRoot: true
         runAsUser: {{ template "postgres.uid" }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 6 }}
+{{- end }}
       initContainers:
 {{- if .Values.timescaledbTune.enabled }}
       - name: tstune

--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -23,6 +23,11 @@ image:
   tag: pg13.4-ts2.4.2-p0
   pullPolicy: Always
 
+# If you pull the image from a private repository you need to create an image pull secret
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# imagePullSecrets:
+# - name: registry-credentials
+
 # By default those secrets are randomly generated.
 # To prevent misconfiguration, modifications from helm upgrade won't be applied to those secrets.
 # As a result changing secrets cannot be done via helm and need manual intervention.


### PR DESCRIPTION
Using a private repository was not possible before, so I added the imagePullSecrets to the StatefulSet.

You can now define an existing secret from the same namespace. Example:

```yaml
image:
  repository: docker.yourcompany.com/timescale/timescaledb-ha
  tag: pg13.4-ts2.4.2-p0
  pullPolicy: IfNotPresent

imagePullSecrets:
- name: registry-credentials
```

Checkout https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ for detailed information.