### PR TITLE
charts/timescaledb-single: keep database credentials after helm uninstall

### DIFF
--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "secrets_credentials" $ }}"
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     app: {{ template "timescaledb.fullname" . }}
     cluster-name: {{ template "clusterName" . }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -5,6 +5,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "secrets_pgbackrest" $ }}"
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}


### PR DESCRIPTION
Since secrets are dynamically created during installation, it is worth keeping them after uninstall if someone would like to still access data on PV.

Note: This feature is currently implemented in tobs CLI. However, since we are moving Secrets ownership to this helm chart, it should live here. The feature is going to be removed from tobs CLI with https://github.com/timescale/tobs/pull/305