### PR TITLE
charts/timescaledb-single: create secrets before installation

### DIFF
--- a/charts/timescaledb-single/templates/secret-certificate.yaml
+++ b/charts/timescaledb-single/templates/secret-certificate.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook-weight": "0"
 type: kubernetes.io/tls
 {{- if .Release.IsUpgrade }}
 stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-certificate" (include "clusterName" .))).stringData }}

--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     app: {{ template "timescaledb.fullname" . }}
     cluster-name: {{ template "clusterName" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook-weight": "0"
 type: Opaque
 {{- if .Release.IsUpgrade }}
 stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" (include "clusterName" .))).stringData }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook-weight": "0"
 type: Opaque
 {{- if .Release.IsUpgrade }}
 stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-pgbackrest" (include "clusterName" .))).stringData }}


### PR DESCRIPTION
By creating secrets before StatefulSet we can ensure existence of said secret and faster installation path.

This can also improve downstream usage in tobs as we can copy this secret to promscale secret earlier.