### PR TITLE
charts/timescaledb-single bump default version to pg14.2-ts2.6.1-p2

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg13.4-ts2.4.2-p0
+  tag: pg14.2-ts2.6.1-p2
   pullPolicy: Always
 
 # By default those secrets are randomly generated.


### PR DESCRIPTION
Bump default version of the database.