### PR TITLE
single: fix secret lookups

### DIFF
--- a/charts/timescaledb-single/templates/secret-certificate.yaml
+++ b/charts/timescaledb-single/templates/secret-certificate.yaml
@@ -13,7 +13,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: kubernetes.io/tls
 {{- if .Release.IsUpgrade }}
-stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-certificate" (include "clusterName" .))).stringData }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-certificate" (include "clusterName" .))).data }}
 {{ else }}
 {{ $ca := genCA (include "clusterName" .) 1826 -}}
 stringData:

--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -15,7 +15,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: Opaque
 {{- if .Release.IsUpgrade }}
-stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" (include "clusterName" .))).stringData }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" (include "clusterName" .))).data }}
 {{ else }}
 stringData:
   PATRONI_SUPERUSER_PASSWORD: {{ default (randAlphaNum 16) .Values.secrets.credentials.PATRONI_SUPERUSER_PASSWORD | quote }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -15,7 +15,7 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: Opaque
 {{- if .Release.IsUpgrade }}
-stringData: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-pgbackrest" (include "clusterName" .))).stringData }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-pgbackrest" (include "clusterName" .))).data }}
 {{- else }}
 stringData:
 {{ toYaml .Values.secrets.pgbackrest | indent 2 }}


### PR DESCRIPTION
It is not possible to do a lookup for `stringData` as this field does not exist in Secret object.