### PR TITLE
Bump timescaledb-ha docker image

### DIFF
--- a/charts/timescaledb-single/values.yaml
+++ b/charts/timescaledb-single/values.yaml
@@ -20,7 +20,7 @@ image:
   # Image was built from
   # https://github.com/timescale/timescaledb-docker-ha
   repository: timescale/timescaledb-ha
-  tag: pg14.2-ts2.6.1-p2
+  tag: pg14.3-ts2.7.0-p0
   pullPolicy: Always
 
 # By default those secrets are randomly generated.


### PR DESCRIPTION
This image contains the latest version of the Promscale extension,
required to work with Promscale 0.11.0