### PR TITLE
Fix duplicate "annotations" keys

### DIFF
--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -5,14 +5,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "secrets_credentials" $ }}
-  annotations:
-    "helm.sh/resource-policy": keep
   labels:
     app: {{ template "timescaledb.fullname" . }}
     cluster-name: {{ template "clusterName" . }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "0"
+    "helm.sh/resource-policy": keep
 type: Opaque
 {{- if .Release.IsUpgrade }}
 data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" (include "clusterName" .))).data }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -5,14 +5,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "secrets_pgbackrest" $ }}
-  annotations:
-    "helm.sh/resource-policy": keep
   labels:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade,post-delete
     "helm.sh/hook-weight": "0"
+    "helm.sh/resource-policy": keep
 type: Opaque
 {{- if .Release.IsUpgrade }}
 data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-pgbackrest" (include "clusterName" .))).data }}


### PR DESCRIPTION
The YAML spec requires mapping keys to be unique and e.g. the Go YAML
parser used by Grafana Tanka errors out if that is not the case:

> line 1160: mapping key "annotations" already defined at line 1155