### PR TITLE
timescaledb-single: fix upgrades of the helm chart when using generated secrets

### DIFF
--- a/charts/timescaledb-single/templates/secret-certificate.yaml
+++ b/charts/timescaledb-single/templates/secret-certificate.yaml
@@ -9,11 +9,11 @@ metadata:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook": pre-install,post-delete
     "helm.sh/hook-weight": "0"
 type: kubernetes.io/tls
 {{- if .Release.IsUpgrade }}
-data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-certificate" (include "clusterName" .))).data }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (include "secrets_certificate" .)).data }}
 {{ else }}
 {{ $ca := genCA (include "clusterName" .) 1826 -}}
 stringData:

--- a/charts/timescaledb-single/templates/secret-patroni.yaml
+++ b/charts/timescaledb-single/templates/secret-patroni.yaml
@@ -9,12 +9,12 @@ metadata:
     app: {{ template "timescaledb.fullname" . }}
     cluster-name: {{ template "clusterName" . }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook": pre-install,post-delete
     "helm.sh/hook-weight": "0"
     "helm.sh/resource-policy": keep
 type: Opaque
 {{- if .Release.IsUpgrade }}
-data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" (include "clusterName" .))).data }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (include "secrets_credentials" .)).data }}
 {{ else }}
 stringData:
   PATRONI_SUPERUSER_PASSWORD: {{ default (randAlphaNum 16) .Values.secrets.credentials.PATRONI_SUPERUSER_PASSWORD | quote }}

--- a/charts/timescaledb-single/templates/secret-pgbackrest.yaml
+++ b/charts/timescaledb-single/templates/secret-pgbackrest.yaml
@@ -9,12 +9,12 @@ metadata:
     app: {{ template "timescaledb.fullname" $ }}
     cluster-name: {{ template "clusterName" $ }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook": pre-install,post-delete
     "helm.sh/hook-weight": "0"
     "helm.sh/resource-policy": keep
 type: Opaque
 {{- if .Release.IsUpgrade }}
-data: {{ (lookup "v1" "Secret" .Release.Namespace (printf "%s-pgbackrest" (include "clusterName" .))).data }}
+data: {{ (lookup "v1" "Secret" .Release.Namespace (include "secrets_pgbackrest" .)).data }}
 {{- else }}
 stringData:
 {{ toYaml .Values.secrets.pgbackrest | indent 2 }}


### PR DESCRIPTION
This is fixing issues found by using helm chart in tobs. Mainly `helm upgrade` is broken due to the following error:
```
Error: UPGRADE FAILED: YAML parse error on tobs/charts/timescaledb-single/templates/secret-pgbackrest.yaml: error converting YAML to JSON: yaml: line 16: mapping values are not allowed in this context
```

The fix is to:
1) remove `pre-upgrade` hook so secret is not removed during upgrade
2) improve lookup function to reuse helper function