### PR TITLE
pgbouncer userlist.txt mountPath correction

### DIFF
--- a/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/statefulset-timescaledb.yaml
@@ -354,7 +354,7 @@ spec:
             name: pgbouncer
             readOnly: true
 {{- if .Values.pgBouncer.userListSecretName }}
-          - mountPath: /etc/pgbouncer/userlist/userlist.txt
+          - mountPath: /etc/pgbouncer/userlist/
             name: pgbouncer-userlist
             readOnly: true
 {{- end }}


### PR DESCRIPTION
The current `mountPath` for the secret containing the `pgbouncer` user list is incorrectly implemented.

In order for the feature to work properly at present, the `auth_file` path in the `pgbouncer` config must be overridden to `/etc/pgbouncer/userlist/userlist.txt/userlist.txt`, because the `mountPath` is mounted as a directory and not a file.

This PR aligns the mount path with the expected location for the `userlist.txt` [as configured by this Helm chart](https://github.com/timescale/timescaledb-kubernetes/blob/88d1bb40521c93feed3b17785d7d1d5c1f56669e/charts/timescaledb-single/values/pgbouncer_customizations.yaml#L9), and given the object layout in [this testing file](https://github.com/timescale/timescaledb-kubernetes/blob/88d1bb40521c93feed3b17785d7d1d5c1f56669e/tests/custom_pgbouncer_user_list.yaml).