### PR TITLE
update documentation relevant to pgbackrest and wal maintenance

### DIFF
--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -254,6 +254,11 @@ Alternatively, you can use the [AWS Management Console](https://s3.console.aws.a
 
 ## Backups
 
+### A Warning Regarding WAL Volume Usage
+If backups are not enabled via `pgbackrest`, the WAL data for the instance will not be maintained. This will result in WAL data filling the volume to capacity, regardless of where that data is stored.
+
+If you intend to use this Helm chart in any operational capacity, configuring and enabling backups is *NOT* optional!
+
 ### Create backups to S3
  the following items are required for you to enable creating backups to S3:
 

--- a/charts/timescaledb-single/admin-guide.md
+++ b/charts/timescaledb-single/admin-guide.md
@@ -257,7 +257,7 @@ Alternatively, you can use the [AWS Management Console](https://s3.console.aws.a
 ### A Warning Regarding WAL Volume Usage
 If backups are not enabled via `pgbackrest`, the WAL data for the instance will not be maintained. This will result in WAL data filling the volume to capacity, regardless of where that data is stored.
 
-If you intend to use this Helm chart in any operational capacity, configuring and enabling backups is *NOT* optional!
+If you intend to use this Helm chart in any operational capacity, configuring and enabling backups is *HIGHLY* recommended.
 
 ### Create backups to S3
  the following items are required for you to enable creating backups to S3:


### PR DESCRIPTION
The documentation neglects to mention the critical role of `pgbackrest` in the care and feeding of WAL data and the subsequent consequences of not configuring backups.

There is a mention of this in the comments buried deep within the chart itself [here](https://github.com/timescale/timescaledb-kubernetes/blob/88d1bb40521c93feed3b17785d7d1d5c1f56669e/charts/timescaledb-single/templates/configmap-scripts.yaml#L20), but it's not explicitly called out anywhere in any readme, leaving users to discover this information for themselves organically, which is very poor UX.

This PR attempts to correct that.