### PR TITLE
timescaledb-single: Remove permission to create services

### DIFF
--- a/charts/timescaledb-single/templates/role-timescaledb.yaml
+++ b/charts/timescaledb-single/templates/role-timescaledb.yaml
@@ -24,10 +24,6 @@ rules:
   # delete is required only for 'patronictl remove'
   - delete
 - apiGroups: [""]
-  resources: ["services"]
-  verbs:
-  - create
-- apiGroups: [""]
   resources:
   - endpoints
   - endpoints/restricted


### PR DESCRIPTION
This commit removes the permission to create services from the timescaledb role. The headless service is created by the helm chart itself, so the permission is not required in our case.

This works but causes a spam of `ERROR: create_config_service failed` in patroni logs. There is already an open issue about this on Patroni's repo zalando/patroni#1132, which once tackled will solve the log spam problem.

This PR also fixes the race in service deletion as reported in #397.

Signed-off-by: Prem Saraswat <prmsrswt@gmail.com>