### PR TITLE
*: improve publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,13 @@ jobs:
           done
 
       - name: Publish releases
+        working-directory: dist
         env:
           AWS_REGION: 'us-east-1'
           AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_SECRET_ACCESS_KEY }}
         run: |
             helm repo add tscharts s3://charts.timescale.com
-            helm s3 push dist/* tscharts --acl public-read --relative --ignore-if-exists
+            for repo in *.tgz; do
+              helm s3 push $repo tscharts --acl public-read --relative --ignore-if-exists
+            done

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/credentials.conf
 **/ci
 charts/repo/
+dist/


### PR DESCRIPTION
Doing `helm s3 push dist/* tscharts` can result in errors as seen in https://github.com/timescale/timescaledb-kubernetes/runs/7390426827?check_suite_focus=true#step:6:12

With this PR chart publishing job will go through all packaged charts and push them one by one instead of relying on shell globing.